### PR TITLE
MP-2159. stAsset/Asset geometric price source.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -423,7 +423,7 @@ checksum = "c80e93d1deccb8588db03945016a292c3c631e6325d349ebb35d2db6f4f946f7"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
- "cw2",
+ "cw2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "schemars",
  "semver",
  "serde",
@@ -441,6 +441,19 @@ dependencies = [
  "cw-storage-plus",
  "schemars",
  "serde",
+]
+
+[[package]]
+name = "cw2"
+version = "1.0.1"
+source = "git+https://github.com/mars-protocol/cw-plus?rev=4014255#4014255fc2d79486e332e02d1ab1421db86f4f0b"
+dependencies = [
+ "cosmwasm-schema",
+ "cosmwasm-std",
+ "cw-storage-plus",
+ "schemars",
+ "serde",
+ "thiserror",
 ]
 
 [[package]]
@@ -854,13 +867,13 @@ dependencies = [
 
 [[package]]
 name = "mars-address-provider"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "bech32",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-storage-plus",
- "cw2",
+ "cw2 1.0.1 (git+https://github.com/mars-protocol/cw-plus?rev=4014255)",
  "mars-owner",
  "mars-red-bank-types",
  "serde",
@@ -869,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "mars-health"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "cosmwasm-std",
  "mars-red-bank-types",
@@ -879,12 +892,12 @@ dependencies = [
 
 [[package]]
 name = "mars-incentives"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-storage-plus",
- "cw2",
+ "cw2 1.0.1 (git+https://github.com/mars-protocol/cw-plus?rev=4014255)",
  "mars-owner",
  "mars-red-bank-types",
  "mars-testing",
@@ -894,7 +907,7 @@ dependencies = [
 
 [[package]]
 name = "mars-integration-tests"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "cosmwasm-std",
@@ -915,10 +928,11 @@ dependencies = [
 
 [[package]]
 name = "mars-oracle-base"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "cosmwasm-std",
  "cw-storage-plus",
+ "cw2 1.0.1 (git+https://github.com/mars-protocol/cw-plus?rev=4014255)",
  "mars-owner",
  "mars-red-bank-types",
  "mars-utils",
@@ -929,12 +943,12 @@ dependencies = [
 
 [[package]]
 name = "mars-oracle-osmosis"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-storage-plus",
- "cw2",
+ "cw2 1.0.1 (git+https://github.com/mars-protocol/cw-plus?rev=4014255)",
  "mars-oracle-base",
  "mars-osmosis",
  "mars-owner",
@@ -949,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "mars-osmosis"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "cosmwasm-std",
  "osmosis-std 0.14.0",
@@ -971,13 +985,13 @@ dependencies = [
 
 [[package]]
 name = "mars-red-bank"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-storage-plus",
  "cw-utils",
- "cw2",
+ "cw2 1.0.1 (git+https://github.com/mars-protocol/cw-plus?rev=4014255)",
  "mars-health",
  "mars-owner",
  "mars-red-bank-types",
@@ -988,7 +1002,7 @@ dependencies = [
 
 [[package]]
 name = "mars-red-bank-types"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -999,7 +1013,7 @@ dependencies = [
 
 [[package]]
 name = "mars-rewards-collector-base"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "cosmwasm-std",
  "cw-storage-plus",
@@ -1014,12 +1028,12 @@ dependencies = [
 
 [[package]]
 name = "mars-rewards-collector-osmosis"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-storage-plus",
- "cw2",
+ "cw2 1.0.1 (git+https://github.com/mars-protocol/cw-plus?rev=4014255)",
  "mars-osmosis",
  "mars-owner",
  "mars-red-bank-types",
@@ -1034,7 +1048,7 @@ dependencies = [
 
 [[package]]
 name = "mars-testing"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "cosmwasm-std",
@@ -1055,7 +1069,7 @@ dependencies = [
 
 [[package]]
 name = "mars-utils"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "cosmwasm-std",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 ]
 
 [workspace.package]
-version       = "1.0.0"
+version       = "1.0.1"
 authors       = [
   "Larry Engineer <larry@delphidigital.io>",
   "Piotr Babel <piotr@delphilabs.io>",
@@ -34,7 +34,7 @@ anyhow            = "1.0.68"
 bech32            = "0.9.1"
 cosmwasm-schema   = "1.1.9"
 cosmwasm-std      = "1.1.9"
-cw2               = "1.0.1"
+cw2               = { git = "https://github.com/mars-protocol/cw-plus", rev = "4014255" }
 cw-multi-test     = "0.16.1"
 cw-storage-plus   = "1.0.1"
 cw-utils          = "1.0.1"

--- a/contracts/oracle/base/Cargo.toml
+++ b/contracts/oracle/base/Cargo.toml
@@ -18,6 +18,7 @@ backtraces = ["cosmwasm-std/backtraces"]
 
 [dependencies]
 cosmwasm-std        = { workspace = true }
+cw2                 = { workspace = true }
 cw-storage-plus     = { workspace = true }
 mars-owner          = { workspace = true }
 mars-red-bank-types = { workspace = true }

--- a/contracts/oracle/base/src/error.rs
+++ b/contracts/oracle/base/src/error.rs
@@ -16,6 +16,9 @@ pub enum ContractError {
     Validation(#[from] ValidationError),
 
     #[error("{0}")]
+    Version(#[from] cw2::VersionError),
+
+    #[error("{0}")]
     Owner(#[from] OwnerError),
 
     #[error("{0}")]

--- a/contracts/oracle/base/src/error.rs
+++ b/contracts/oracle/base/src/error.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{ConversionOverflowError, StdError};
+use cosmwasm_std::{ConversionOverflowError, OverflowError, StdError};
 use mars_owner::OwnerError;
 use mars_red_bank_types::error::MarsError;
 use mars_utils::error::ValidationError;
@@ -20,6 +20,9 @@ pub enum ContractError {
 
     #[error("{0}")]
     ConversionOverflow(#[from] ConversionOverflowError),
+
+    #[error("{0}")]
+    Overflow(#[from] OverflowError),
 
     #[error("Invalid price source: {reason}")]
     InvalidPriceSource {

--- a/contracts/oracle/osmosis/src/contract.rs
+++ b/contracts/oracle/osmosis/src/contract.rs
@@ -17,6 +17,7 @@ pub mod entry {
     use mars_red_bank_types::oracle::{ExecuteMsg, InstantiateMsg, QueryMsg};
 
     use super::*;
+    use crate::migrations;
 
     #[entry_point]
     pub fn instantiate(
@@ -42,5 +43,10 @@ pub mod entry {
     #[entry_point]
     pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> ContractResult<Binary> {
         OsmosisOracle::default().query(deps, env, msg)
+    }
+
+    #[entry_point]
+    pub fn migrate(deps: DepsMut, _env: Env, _msg: Empty) -> ContractResult<Response> {
+        migrations::v1_0_0::migrate(deps)
     }
 }

--- a/contracts/oracle/osmosis/src/lib.rs
+++ b/contracts/oracle/osmosis/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod contract;
 mod helpers;
+mod migrations;
 pub mod msg;
 mod price_source;
 

--- a/contracts/oracle/osmosis/src/migrations.rs
+++ b/contracts/oracle/osmosis/src/migrations.rs
@@ -1,0 +1,47 @@
+/// Migration logic for Oracle contract with version: 1.0.0
+pub mod v1_0_0 {
+    use cosmwasm_std::{DepsMut, Response};
+    use mars_oracle_base::ContractResult;
+
+    use crate::contract::{CONTRACT_NAME, CONTRACT_VERSION};
+
+    const FROM_VERSION: &str = "1.0.0";
+
+    pub fn migrate(deps: DepsMut) -> ContractResult<Response> {
+        // make sure we're migrating the correct contract and from the correct version
+        cw2::assert_contract_version(deps.as_ref().storage, CONTRACT_NAME, FROM_VERSION)?;
+
+        // update contract version
+        cw2::set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+
+        Ok(Response::new()
+            .add_attribute("action", "migrate")
+            .add_attribute("from_version", FROM_VERSION)
+            .add_attribute("to_version", CONTRACT_VERSION))
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use cosmwasm_std::{attr, testing::mock_dependencies};
+
+        use super::*;
+
+        #[test]
+        fn proper_migration() {
+            let mut deps = mock_dependencies();
+
+            cw2::set_contract_version(deps.as_mut().storage, CONTRACT_NAME, FROM_VERSION).unwrap();
+
+            let res = migrate(deps.as_mut()).unwrap();
+            assert_eq!(res.messages, vec![]);
+            assert_eq!(
+                res.attributes,
+                vec![
+                    attr("action", "migrate"),
+                    attr("from_version", "1.0.0"),
+                    attr("to_version", "1.0.1")
+                ]
+            );
+        }
+    }
+}

--- a/contracts/oracle/osmosis/src/price_source.rs
+++ b/contracts/oracle/osmosis/src/price_source.rs
@@ -63,6 +63,15 @@ pub struct DowntimeDetector {
     pub recovery: u64,
 }
 
+impl DowntimeDetector {
+    fn fmt(opt_dd: &Option<Self>) -> String {
+        match opt_dd {
+            None => "None".to_string(),
+            Some(dd) => format!("Some({dd})"),
+        }
+    }
+}
+
 impl fmt::Display for DowntimeDetector {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{:?}:{}", self.downtime, self.recovery)
@@ -152,10 +161,7 @@ impl fmt::Display for OsmosisPriceSource {
                 window_size,
                 downtime_detector,
             } => {
-                let dd_fmt = match downtime_detector {
-                    None => "None".to_string(),
-                    Some(dd) => format!("Some({dd})"),
-                };
+                let dd_fmt = DowntimeDetector::fmt(downtime_detector);
                 format!("arithmetic_twap:{pool_id}:{window_size}:{dd_fmt}")
             }
             OsmosisPriceSource::GeometricTwap {
@@ -163,10 +169,7 @@ impl fmt::Display for OsmosisPriceSource {
                 window_size,
                 downtime_detector,
             } => {
-                let dd_fmt = match downtime_detector {
-                    None => "None".to_string(),
-                    Some(dd) => format!("Some({dd})"),
-                };
+                let dd_fmt = DowntimeDetector::fmt(downtime_detector);
                 format!("geometric_twap:{pool_id}:{window_size}:{dd_fmt}")
             }
             OsmosisPriceSource::XykLiquidityToken {
@@ -178,10 +181,7 @@ impl fmt::Display for OsmosisPriceSource {
                 window_size,
                 downtime_detector,
             } => {
-                let dd_fmt = match downtime_detector {
-                    None => "None".to_string(),
-                    Some(dd) => format!("Some({dd})"),
-                };
+                let dd_fmt = DowntimeDetector::fmt(downtime_detector);
                 format!("staked_geometric_twap:{transitive_denom}:{pool_id}:{window_size}:{dd_fmt}")
             }
         };

--- a/contracts/oracle/osmosis/src/price_source.rs
+++ b/contracts/oracle/osmosis/src/price_source.rs
@@ -112,6 +112,30 @@ pub enum OsmosisPriceSource {
     XykLiquidityToken {
         pool_id: u64,
     },
+    /// Osmosis geometric twap price quoted in OSMO for staked asset.
+    ///
+    /// Example:
+    /// stATOM/OSMO = stATOM/ATOM * ATOM/OSMO
+    /// where:
+    /// - stATOM/ATOM price calculated using the geometric TWAP from the stATOM/ATOM pool.
+    /// - ATOM/OSMO price comes from the Mars Oracle contract.
+    ///
+    /// NOTE: `pool_id` must point to stAsset/Asset Osmosis pool.
+    /// Asset/OSMO price source should be available in the Mars Oracle contract.
+    StakedGeometricTwap {
+        /// Transitive denom for which we query price in OSMO
+        transitive_denom: String,
+
+        /// Pool id for stAsset/Asset pool
+        pool_id: u64,
+
+        /// Window size in seconds representing the entire window for which 'geometric' price is calculated.
+        /// Value should be <= 172800 sec (48 hours).
+        window_size: u64,
+
+        /// Detect when the chain is recovering from downtime
+        downtime_detector: Option<DowntimeDetector>,
+    },
 }
 
 impl fmt::Display for OsmosisPriceSource {
@@ -148,6 +172,18 @@ impl fmt::Display for OsmosisPriceSource {
             OsmosisPriceSource::XykLiquidityToken {
                 pool_id,
             } => format!("xyk_liquidity_token:{pool_id}"),
+            OsmosisPriceSource::StakedGeometricTwap {
+                transitive_denom,
+                pool_id,
+                window_size,
+                downtime_detector,
+            } => {
+                let dd_fmt = match downtime_detector {
+                    None => "None".to_string(),
+                    Some(dd) => format!("Some({dd})"),
+                };
+                format!("staked_geometric_twap:{transitive_denom}:{pool_id}:{window_size}:{dd_fmt}")
+            }
         };
         write!(f, "{label}")
     }
@@ -193,6 +229,16 @@ impl PriceSource<Empty> for OsmosisPriceSource {
             } => {
                 let pool = query_pool(querier, *pool_id)?;
                 helpers::assert_osmosis_xyk_pool(&pool)
+            }
+            OsmosisPriceSource::StakedGeometricTwap {
+                transitive_denom,
+                pool_id,
+                window_size,
+                downtime_detector,
+            } => {
+                let pool = query_pool(querier, *pool_id)?;
+                helpers::assert_osmosis_pool_assets(&pool, denom, transitive_denom)?;
+                helpers::assert_osmosis_twap(*window_size, downtime_detector)
             }
         }
     }
@@ -243,6 +289,25 @@ impl PriceSource<Empty> for OsmosisPriceSource {
                 base_denom,
                 price_sources,
             ),
+            OsmosisPriceSource::StakedGeometricTwap {
+                transitive_denom,
+                pool_id,
+                window_size,
+                downtime_detector,
+            } => {
+                Self::chain_recovered(deps, downtime_detector)?;
+
+                Self::query_staked_asset_price(
+                    deps,
+                    env,
+                    denom,
+                    transitive_denom,
+                    base_denom,
+                    *pool_id,
+                    *window_size,
+                    price_sources,
+                )
+            }
         }
     }
 }
@@ -310,6 +375,43 @@ impl OsmosisPriceSource {
         let total_shares = Pool::unwrap_coin(&pool.total_shares)?.amount;
 
         Ok(Decimal::from_ratio(pool_value_u128, total_shares))
+    }
+
+    /// Staked asset price quoted in OSMO.
+    ///
+    /// stAsset/OSMO = stAsset/Asset * Asset/OSMO
+    /// where:
+    /// - stAsset/Asset price calculated using the geometric TWAP from the stAsset/Asset pool.
+    /// - Asset/OSMO price comes from the Mars Oracle contract.
+    fn query_staked_asset_price(
+        deps: &Deps,
+        env: &Env,
+        denom: &str,
+        transitive_denom: &str,
+        base_denom: &str,
+        pool_id: u64,
+        window_size: u64,
+        price_sources: &Map<&str, OsmosisPriceSource>,
+    ) -> ContractResult<Decimal> {
+        let start_time = env.block.time.seconds() - window_size;
+        let staked_price = query_geometric_twap_price(
+            &deps.querier,
+            pool_id,
+            denom,
+            transitive_denom,
+            start_time,
+        )?;
+
+        // use current price source
+        let transitive_price = price_sources.load(deps.storage, transitive_denom)?.query_price(
+            deps,
+            env,
+            transitive_denom,
+            base_denom,
+            price_sources,
+        )?;
+
+        staked_price.checked_mul(transitive_price).map_err(Into::into)
     }
 }
 
@@ -380,6 +482,31 @@ mod tests {
             }),
         };
         assert_eq!(ps.to_string(), "geometric_twap:123:300:Some(Duration30m:568)");
+    }
+
+    #[test]
+    fn display_staked_geometric_twap_price_source() {
+        let ps = OsmosisPriceSource::StakedGeometricTwap {
+            transitive_denom: "transitive".to_string(),
+            pool_id: 123,
+            window_size: 300,
+            downtime_detector: None,
+        };
+        assert_eq!(ps.to_string(), "staked_geometric_twap:transitive:123:300:None");
+
+        let ps = OsmosisPriceSource::StakedGeometricTwap {
+            transitive_denom: "transitive".to_string(),
+            pool_id: 123,
+            window_size: 300,
+            downtime_detector: Some(DowntimeDetector {
+                downtime: Downtime::Duration30m,
+                recovery: 568,
+            }),
+        };
+        assert_eq!(
+            ps.to_string(),
+            "staked_geometric_twap:transitive:123:300:Some(Duration30m:568)"
+        );
     }
 
     #[test]

--- a/contracts/oracle/osmosis/src/price_source.rs
+++ b/contracts/oracle/osmosis/src/price_source.rs
@@ -123,6 +123,9 @@ pub enum OsmosisPriceSource {
     },
     /// Osmosis geometric twap price quoted in OSMO for staked asset.
     ///
+    /// Equation to calculate the price:
+    /// stAsset/OSMO = stAsset/Asset * Asset/OSMO
+    ///
     /// Example:
     /// stATOM/OSMO = stATOM/ATOM * ATOM/OSMO
     /// where:
@@ -132,7 +135,8 @@ pub enum OsmosisPriceSource {
     /// NOTE: `pool_id` must point to stAsset/Asset Osmosis pool.
     /// Asset/OSMO price source should be available in the Mars Oracle contract.
     StakedGeometricTwap {
-        /// Transitive denom for which we query price in OSMO
+        /// Transitive denom for which we query price in OSMO. It refers to 'Asset' in the equation:
+        /// stAsset/OSMO = stAsset/Asset * Asset/OSMO
         transitive_denom: String,
 
         /// Pool id for stAsset/Asset pool

--- a/contracts/oracle/osmosis/tests/helpers.rs
+++ b/contracts/oracle/osmosis/tests/helpers.rs
@@ -41,6 +41,17 @@ pub fn setup_test() -> OwnedDeps<MockStorage, MockApi, MarsMockQuerier> {
         prepare_query_pool_response(89, &assets, &[5000u64, 5000u64], &coin(10000, "gamm/pool/89")),
     );
 
+    let assets = vec![coin(12345, "ustatom"), coin(88888, "uatom")];
+    deps.querier.set_query_pool_response(
+        803,
+        prepare_query_pool_response(
+            803,
+            &assets,
+            &[5000u64, 5000u64],
+            &coin(10000, "gamm/pool/803"),
+        ),
+    );
+
     let assets = vec![coin(100000, "uusdc"), coin(100000, "uusdt"), coin(100000, "udai")];
     deps.querier.set_query_pool_response(
         3333,

--- a/contracts/oracle/osmosis/tests/test_set_price_source.rs
+++ b/contracts/oracle/osmosis/tests/test_set_price_source.rs
@@ -522,6 +522,174 @@ fn setting_price_source_geometric_twap_successfully() {
 }
 
 #[test]
+fn setting_price_source_staked_geometric_twap_with_invalid_params() {
+    let mut deps = helpers::setup_test();
+
+    let mut set_price_source_twap =
+        |denom: &str,
+         transitive_denom: &str,
+         pool_id: u64,
+         window_size: u64,
+         downtime_detector: Option<DowntimeDetector>| {
+            execute(
+                deps.as_mut(),
+                mock_env(),
+                mock_info("owner"),
+                ExecuteMsg::SetPriceSource {
+                    denom: denom.to_string(),
+                    price_source: OsmosisPriceSource::StakedGeometricTwap {
+                        transitive_denom: transitive_denom.to_string(),
+                        pool_id,
+                        window_size,
+                        downtime_detector,
+                    },
+                },
+            )
+        };
+
+    // attempting to use a pool that does not contain the denom of interest; should fail
+    let err = set_price_source_twap("ustatom", "umars", 803, 86400, None).unwrap_err();
+    assert_eq!(
+        err,
+        ContractError::InvalidPriceSource {
+            reason: "pool 803 does not contain the base denom umars".to_string()
+        }
+    );
+    let err = set_price_source_twap("umars", "uatom", 803, 86400, None).unwrap_err();
+    assert_eq!(
+        err,
+        ContractError::InvalidPriceSource {
+            reason: "pool 803 does not contain umars".to_string()
+        }
+    );
+
+    // attempting to use a pool that contains more than two assets; should fail
+    let err = set_price_source_twap("ustatom", "uatom", 3333, 86400, None).unwrap_err();
+    assert_eq!(
+        err,
+        ContractError::InvalidPriceSource {
+            reason: "expecting pool 3333 to contain exactly two coins; found 3".to_string()
+        }
+    );
+
+    // attempting to use not XYK pool
+    let err = set_price_source_twap("ustatom", "uatom", 4444, 86400, None).unwrap_err();
+    assert_eq!(
+        err,
+        ContractError::InvalidPriceSource {
+            reason: "assets in pool 4444 do not have equal weights".to_string()
+        }
+    );
+
+    // attempting to set window_size bigger than 172800 sec (48h)
+    let err = set_price_source_twap("ustatom", "uatom", 803, 172801, None).unwrap_err();
+    assert_eq!(
+        err,
+        ContractError::InvalidPriceSource {
+            reason: "expecting window size to be within 172800 sec".to_string()
+        }
+    );
+
+    // attempting to set downtime recovery to 0
+    let err = set_price_source_twap(
+        "ustatom",
+        "uatom",
+        803,
+        86400,
+        Some(DowntimeDetector {
+            downtime: Downtime::Duration30s,
+            recovery: 0,
+        }),
+    )
+    .unwrap_err();
+    assert_eq!(
+        err,
+        ContractError::InvalidPriceSource {
+            reason: "downtime recovery can't be 0".to_string()
+        }
+    );
+}
+
+#[test]
+fn setting_price_source_staked_geometric_twap_successfully() {
+    let mut deps = helpers::setup_test();
+
+    // properly set twap price source
+    let res = execute(
+        deps.as_mut(),
+        mock_env(),
+        mock_info("owner"),
+        ExecuteMsg::SetPriceSource {
+            denom: "ustatom".to_string(),
+            price_source: OsmosisPriceSource::StakedGeometricTwap {
+                transitive_denom: "uatom".to_string(),
+                pool_id: 803,
+                window_size: 86400,
+                downtime_detector: None,
+            },
+        },
+    )
+    .unwrap();
+    assert_eq!(res.messages.len(), 0);
+
+    let res: PriceSourceResponse = helpers::query(
+        deps.as_ref(),
+        QueryMsg::PriceSource {
+            denom: "ustatom".to_string(),
+        },
+    );
+    assert_eq!(
+        res.price_source,
+        OsmosisPriceSource::StakedGeometricTwap {
+            transitive_denom: "uatom".to_string(),
+            pool_id: 803,
+            window_size: 86400,
+            downtime_detector: None
+        }
+    );
+
+    // properly set twap price source with downtime detector
+    let res = execute(
+        deps.as_mut(),
+        mock_env(),
+        mock_info("owner"),
+        ExecuteMsg::SetPriceSource {
+            denom: "ustatom".to_string(),
+            price_source: OsmosisPriceSource::StakedGeometricTwap {
+                transitive_denom: "uatom".to_string(),
+                pool_id: 803,
+                window_size: 86400,
+                downtime_detector: Some(DowntimeDetector {
+                    downtime: Downtime::Duration30m,
+                    recovery: 360u64,
+                }),
+            },
+        },
+    )
+    .unwrap();
+    assert_eq!(res.messages.len(), 0);
+
+    let res: PriceSourceResponse = helpers::query(
+        deps.as_ref(),
+        QueryMsg::PriceSource {
+            denom: "ustatom".to_string(),
+        },
+    );
+    assert_eq!(
+        res.price_source,
+        OsmosisPriceSource::StakedGeometricTwap {
+            transitive_denom: "uatom".to_string(),
+            pool_id: 803,
+            window_size: 86400,
+            downtime_detector: Some(DowntimeDetector {
+                downtime: Downtime::Duration30m,
+                recovery: 360u64
+            })
+        }
+    );
+}
+
+#[test]
 fn setting_price_source_xyk_lp() {
     let mut deps = helpers::setup_test();
 

--- a/schemas/mars-address-provider/mars-address-provider.json
+++ b/schemas/mars-address-provider/mars-address-provider.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "mars-address-provider",
-  "contract_version": "1.0.0",
+  "contract_version": "1.0.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/schemas/mars-incentives/mars-incentives.json
+++ b/schemas/mars-incentives/mars-incentives.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "mars-incentives",
-  "contract_version": "1.0.0",
+  "contract_version": "1.0.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/schemas/mars-oracle-osmosis/mars-oracle-osmosis.json
+++ b/schemas/mars-oracle-osmosis/mars-oracle-osmosis.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "mars-oracle-osmosis",
-  "contract_version": "1.0.0",
+  "contract_version": "1.0.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/schemas/mars-oracle-osmosis/mars-oracle-osmosis.json
+++ b/schemas/mars-oracle-osmosis/mars-oracle-osmosis.json
@@ -297,6 +297,53 @@
               }
             },
             "additionalProperties": false
+          },
+          {
+            "description": "Osmosis geometric twap price quoted in OSMO for staked asset.\n\nExample: stATOM/OSMO = stATOM/ATOM * ATOM/OSMO where: - stATOM/ATOM price calculated using the geometric TWAP from the stATOM/ATOM pool. - ATOM/OSMO price comes from the Mars Oracle contract.\n\nNOTE: `pool_id` must point to stAsset/Asset Osmosis pool. Asset/OSMO price source should be available in the Mars Oracle contract.",
+            "type": "object",
+            "required": [
+              "staked_geometric_twap"
+            ],
+            "properties": {
+              "staked_geometric_twap": {
+                "type": "object",
+                "required": [
+                  "pool_id",
+                  "transitive_denom",
+                  "window_size"
+                ],
+                "properties": {
+                  "downtime_detector": {
+                    "description": "Detect when the chain is recovering from downtime",
+                    "anyOf": [
+                      {
+                        "$ref": "#/definitions/DowntimeDetector"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "pool_id": {
+                    "description": "Pool id for stAsset/Asset pool",
+                    "type": "integer",
+                    "format": "uint64",
+                    "minimum": 0.0
+                  },
+                  "transitive_denom": {
+                    "description": "Transitive denom for which we query price in OSMO",
+                    "type": "string"
+                  },
+                  "window_size": {
+                    "description": "Window size in seconds representing the entire window for which 'geometric' price is calculated. Value should be <= 172800 sec (48 hours).",
+                    "type": "integer",
+                    "format": "uint64",
+                    "minimum": 0.0
+                  }
+                }
+              }
+            },
+            "additionalProperties": false
           }
         ]
       },

--- a/schemas/mars-oracle-osmosis/mars-oracle-osmosis.json
+++ b/schemas/mars-oracle-osmosis/mars-oracle-osmosis.json
@@ -299,7 +299,7 @@
             "additionalProperties": false
           },
           {
-            "description": "Osmosis geometric twap price quoted in OSMO for staked asset.\n\nExample: stATOM/OSMO = stATOM/ATOM * ATOM/OSMO where: - stATOM/ATOM price calculated using the geometric TWAP from the stATOM/ATOM pool. - ATOM/OSMO price comes from the Mars Oracle contract.\n\nNOTE: `pool_id` must point to stAsset/Asset Osmosis pool. Asset/OSMO price source should be available in the Mars Oracle contract.",
+            "description": "Osmosis geometric twap price quoted in OSMO for staked asset.\n\nEquation to calculate the price: stAsset/OSMO = stAsset/Asset * Asset/OSMO\n\nExample: stATOM/OSMO = stATOM/ATOM * ATOM/OSMO where: - stATOM/ATOM price calculated using the geometric TWAP from the stATOM/ATOM pool. - ATOM/OSMO price comes from the Mars Oracle contract.\n\nNOTE: `pool_id` must point to stAsset/Asset Osmosis pool. Asset/OSMO price source should be available in the Mars Oracle contract.",
             "type": "object",
             "required": [
               "staked_geometric_twap"
@@ -331,7 +331,7 @@
                     "minimum": 0.0
                   },
                   "transitive_denom": {
-                    "description": "Transitive denom for which we query price in OSMO",
+                    "description": "Transitive denom for which we query price in OSMO. It refers to 'Asset' in the equation: stAsset/OSMO = stAsset/Asset * Asset/OSMO",
                     "type": "string"
                   },
                   "window_size": {

--- a/schemas/mars-red-bank/mars-red-bank.json
+++ b/schemas/mars-red-bank/mars-red-bank.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "mars-red-bank",
-  "contract_version": "1.0.0",
+  "contract_version": "1.0.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/schemas/mars-rewards-collector-osmosis/mars-rewards-collector-osmosis.json
+++ b/schemas/mars-rewards-collector-osmosis/mars-rewards-collector-osmosis.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "mars-rewards-collector-osmosis",
-  "contract_version": "1.0.0",
+  "contract_version": "1.0.1",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",

--- a/scripts/types/generated/mars-oracle-osmosis/MarsOracleOsmosis.types.ts
+++ b/scripts/types/generated/mars-oracle-osmosis/MarsOracleOsmosis.types.ts
@@ -59,6 +59,15 @@ export type OsmosisPriceSource =
         [k: string]: unknown
       }
     }
+  | {
+      staked_geometric_twap: {
+        downtime_detector?: DowntimeDetector | null
+        pool_id: number
+        transitive_denom: string
+        window_size: number
+        [k: string]: unknown
+      }
+    }
 export type Decimal = string
 export type Downtime =
   | 'duration30s'


### PR DESCRIPTION
stATOM oracle we're gonna use the TWAP from the stATOM/ATOM pool
so to standardize to OSMO we're gonna need to do: stATOM/ATOM * ATOM/OSMO
ATOM/OSMO from our current feed