### PR TITLE
Make README clear on yarn usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,22 +68,25 @@ A bug bounty is currently open for these contracts. See details [here][2].
 
 - Create the build folder:
 
-   ```bash
-   yarn build
-   ```
+  ```bash
+  cd scripts
+  yarn
+  yarn build
+  ```
 
 - Compile all contracts:
 
-   ```bash
-   cargo make rust-optimizer
-   ```
+  ```bash
+  cargo make rust-optimizer
+  ```
 
 - Formatting:
 
-   ```bash
-   yarn format
-   yarn lint
-   ```
+  ```bash
+  cd scripts
+  yarn format
+  yarn lint
+  ```
 
 This compiles and optimizes all contracts, storing them in `/artifacts` directory along with `checksum.txt` which contains sha256 hashes of each of the `.wasm` files (The script just uses CosmWasm's [rust-optimizer][9]).
 


### PR DESCRIPTION
The package.json is in the `scripts` directory so `yarn build` does not
work when run from the root of the project. Additionally `yarn format`
and `yarn lint`need to be run from the`scripts` directory.
