### PR TITLE
Improve pyth base dec

### DIFF
--- a/contracts/oracle/base/src/contract.rs
+++ b/contracts/oracle/base/src/contract.rs
@@ -73,7 +73,6 @@ where
             deps.storage,
             &Config {
                 base_denom: msg.base_denom,
-                base_denom_decimals: msg.base_denom_decimals,
             },
         )?;
 
@@ -97,8 +96,7 @@ where
             } => self.remove_price_source(deps, info.sender, denom),
             ExecuteMsg::UpdateConfig {
                 base_denom,
-                base_denom_decimals,
-            } => self.update_config(deps, info.sender, base_denom, base_denom_decimals),
+            } => self.update_config(deps, info.sender, base_denom),
         }
     }
 
@@ -173,7 +171,6 @@ where
         deps: DepsMut<C>,
         sender_addr: Addr,
         base_denom: Option<String>,
-        base_demom_decimals: Option<u8>,
     ) -> ContractResult<Response> {
         self.owner.assert_owner(deps.storage, &sender_addr)?;
 
@@ -183,17 +180,13 @@ where
 
         let mut config = self.config.load(deps.storage)?;
         let prev_base_denom = config.base_denom.clone();
-        let prev_base_denom_decimals = config.base_denom_decimals;
         config.base_denom = base_denom.unwrap_or(config.base_denom);
-        config.base_denom_decimals = base_demom_decimals.unwrap_or(config.base_denom_decimals);
         self.config.save(deps.storage, &config)?;
 
         let response = Response::new()
             .add_attribute("action", "update_config")
             .add_attribute("prev_base_denom", prev_base_denom)
-            .add_attribute("base_denom", config.base_denom)
-            .add_attribute("prev_base_denom_decimals", prev_base_denom_decimals.to_string())
-            .add_attribute("base_denom_decimals", config.base_denom_decimals.to_string());
+            .add_attribute("base_denom", config.base_denom);
 
         Ok(response)
     }
@@ -205,7 +198,6 @@ where
             owner: owner_state.owner,
             proposed_new_owner: owner_state.proposed,
             base_denom: cfg.base_denom,
-            base_denom_decimals: cfg.base_denom_decimals,
         })
     }
 

--- a/contracts/oracle/base/src/error.rs
+++ b/contracts/oracle/base/src/error.rs
@@ -1,6 +1,6 @@
 use cosmwasm_std::{
-    CheckedFromRatioError, CheckedMultiplyRatioError, ConversionOverflowError, OverflowError,
-    StdError,
+    CheckedFromRatioError, CheckedMultiplyRatioError, ConversionOverflowError,
+    DecimalRangeExceeded, OverflowError, StdError,
 };
 use mars_owner::OwnerError;
 use mars_red_bank_types::error::MarsError;
@@ -35,6 +35,9 @@ pub enum ContractError {
 
     #[error("{0}")]
     CheckedFromRatio(#[from] CheckedFromRatioError),
+
+    #[error("{0}")]
+    DecimalRangeExceeded(#[from] DecimalRangeExceeded),
 
     #[error("Invalid price source: {reason}")]
     InvalidPriceSource {

--- a/contracts/oracle/base/src/traits.rs
+++ b/contracts/oracle/base/src/traits.rs
@@ -32,7 +32,6 @@ where
     /// - `config.base_denom`: The coin in which the price is to be denominated in.
     ///   For example, if `denom` is uatom and `base_denom` is uosmo, the
     ///   function should return how many uosmo is per one uatom.
-    /// - `config.base_denom_decimals`: The coin decimals used for price normalization.
     ///
     /// - `price_sources`: A map that stores the price source for each coin.
     ///   This is necessary because for some coins, in order to calculate its

--- a/contracts/oracle/osmosis/src/price_source.rs
+++ b/contracts/oracle/osmosis/src/price_source.rs
@@ -156,6 +156,8 @@ pub enum OsmosisPriceSource<T> {
         contract_addr: T,
 
         /// Price feed id of an asset from the list: https://pyth.network/developers/price-feed-ids
+        /// We can't verify what denoms consist of the price feed.
+        /// Be very careful when adding it !!!
         price_feed_id: PriceIdentifier,
 
         /// The maximum number of seconds since the last price was by an oracle, before
@@ -166,15 +168,15 @@ pub enum OsmosisPriceSource<T> {
         ///
         /// Pyth prices are denominated in USD so basically it means how much 1 USDC, 1 ATOM, 1 OSMO is worth in USD (NOT 1 uusdc, 1 uatom, 1 uosmo).
         /// We have to normalize it. We should get how much 1 utoken is worth in uusd. For example:
-        /// denom_decimals (OSMO) = 6
-        /// base_denom_decimals (USD) = 6
+        /// - base_denom = uusd
+        /// - price source set for usd (e.g. FIXED price source where 1 usd = 1000000 uusd)
+        /// - denom_decimals (ATOM) = 6
         ///
         /// 1 OSMO = 10^6 uosmo
-        /// 1 USD = 10^6 uusd
         ///
         /// osmo_price_in_usd = 0.59958994
-        /// uosmo_price_in_uusd = osmo_price_in_usd / 10^denom_decimals * 10^base_denom_decimals =
-        /// uosmo_price_in_uusd = 0.59958994 * 10^(-6) * 10^6 = 0.59958994
+        /// uosmo_price_in_uusd = osmo_price_in_usd * usd_price_in_base_denom / 10^denom_decimals =
+        /// uosmo_price_in_uusd = 0.59958994 * 1000000 * 10^(-6) = 0.59958994
         denom_decimals: u8,
     },
     /// Liquid Staking Derivatives (LSD) price quoted in USD based on data from Pyth, Osmosis and Stride.
@@ -691,7 +693,7 @@ impl OsmosisPriceSourceChecked {
         config: &Config,
         price_sources: &Map<&str, OsmosisPriceSourceChecked>,
     ) -> ContractResult<Decimal> {
-        // use current price source for usd
+        // Use current price source for USD to check how much 1 USD is worth in base_denom
         let usd_price = price_sources.load(deps.storage, "usd")?.query_price(
             deps,
             env,
@@ -746,46 +748,59 @@ impl OsmosisPriceSourceChecked {
 /// price: 1365133270
 /// The confidence interval is 574566 * 10^(-8) = $0.00574566, and the price is 1365133270 * 10^(-8) = $13.6513327.
 ///
-/// Moreover, we have to represent the price for utoken in uusd (instead of token/USD).
+/// Moreover, we have to represent the price for utoken in base_denom.
 /// Pyth price should be normalized with token decimals.
 ///
-/// Let's try to convert ATOM/USD reported by Pyth to uatom/uusd:
-/// denom_decimals (ATOM) = 6
-/// base_denom_decimals (USD) = 6
+/// Let's try to convert ATOM/USD reported by Pyth to uatom/base_denom:
+/// - base_denom = uusd
+/// - price source set for usd (e.g. FIXED price source where 1 usd = 1000000 uusd)
+/// - denom_decimals (ATOM) = 6
 ///
 /// 1 ATOM = 10^6 uatom
-/// 1 USD = 10^6 uusd
-/// ///
+///
 /// 1 ATOM = price * 10^expo USD
-/// 10^6 uatom = price * 10^expo * 10^6 uusd
-/// uatom = price * 10^expo * 10^6 / 10^6 uusd
-/// uatom = price * 10^expo * 10^6 * 10^(-6) uusd
-/// uatom/uusd = 1365133270 * 10^(-8) * 10^6 * 10^(-6)
+/// 10^6 uatom = price * 10^expo * 1000000 uusd
+/// uatom = price * 10^expo * 1000000 / 10^6 uusd
+/// uatom = price * 10^expo * 1000000 * 10^(-6) uusd
+/// uatom/uusd = 1365133270 * 10^(-8) * 1000000 * 10^(-6)
 /// uatom/uusd = 1365133270 * 10^(-8) = 13.6513327
 ///
 /// Generalized formula:
-/// utoken/uusd = price * 10^expo * 10^base_denom_decimals * 10^(-denom_decimals)
-///
-/// NOTE: if we don't introduce base_denom decimals we can overflow.
+/// utoken/uusd = price * 10^expo * usd_price_in_base_denom * 10^(-denom_decimals)
 pub fn scale_pyth_price(
     value: u128,
     expo: i32,
     denom_decimals: u8,
     usd_price: Decimal,
 ) -> ContractResult<Decimal> {
-    let denom_scaled = Decimal::from_atomics(1u128, denom_decimals as u32)?;
-
     let target_expo = Uint128::from(10u8).checked_pow(expo.unsigned_abs())?;
-    if expo < 0 {
-        let pyth_price = Decimal::checked_from_ratio(value, target_expo)?;
-        let price = pyth_price.checked_mul(usd_price)?.checked_mul(denom_scaled)?;
-        Ok(price)
+    let pyth_price = if expo < 0 {
+        Decimal::checked_from_ratio(value, target_expo)?
     } else {
         let res = Uint128::from(value).checked_mul(target_expo)?;
-        let pyth_price = Decimal::from_ratio(res, 1u128);
-        let price = pyth_price.checked_mul(denom_scaled)?.checked_mul(usd_price)?;
-        Ok(price)
-    }
+        Decimal::from_ratio(res, 1u128)
+    };
+
+    let denom_scaled = Decimal::from_atomics(1u128, denom_decimals as u32)?;
+    
+    // Multiplication order matters !!! It can overflow doing different ways.
+    // usd_price is represented in smallest unit so it can be quite big number and can be used to reduce number of decimals.
+    //
+    // Let's assume that:
+    // - usd_price = 1000000 = 10^6
+    // - expo = -8
+    // - denom_decimals = 18
+    //
+    // If we multiply usd_price by denom_scaled firstly we will decrease number of decimals used in next multiplication by pyth_price:
+    // 10^6 * 10^(-18) = 10^(-12)
+    // 12 decimals used.
+    //
+    // BUT if we multiply pyth_price by denom_scaled:
+    // 10^(-8) * 10^(-18) = 10^(-26)
+    // 26 decimals used (overflow) !!!
+    let price = usd_price.checked_mul(denom_scaled)?.checked_mul(pyth_price)?;
+
+    Ok(price)
 }
 
 #[cfg(test)]

--- a/contracts/oracle/osmosis/src/price_source.rs
+++ b/contracts/oracle/osmosis/src/price_source.rs
@@ -782,7 +782,7 @@ pub fn scale_pyth_price(
     };
 
     let denom_scaled = Decimal::from_atomics(1u128, denom_decimals as u32)?;
-    
+
     // Multiplication order matters !!! It can overflow doing different ways.
     // usd_price is represented in smallest unit so it can be quite big number and can be used to reduce number of decimals.
     //

--- a/contracts/oracle/osmosis/src/price_source.rs
+++ b/contracts/oracle/osmosis/src/price_source.rs
@@ -491,11 +491,12 @@ impl PriceSourceChecked<Empty> for OsmosisPriceSourceChecked {
             } => Ok(Self::query_pyth_price(
                 deps,
                 env,
-                config,
                 contract_addr.to_owned(),
                 *price_feed_id,
                 *max_staleness,
                 *denom_decimals,
+                config,
+                price_sources,
             )?),
             OsmosisPriceSourceChecked::Lsd {
                 transitive_denom,
@@ -683,12 +684,22 @@ impl OsmosisPriceSourceChecked {
     fn query_pyth_price(
         deps: &Deps,
         env: &Env,
-        config: &Config,
         contract_addr: Addr,
         price_feed_id: PriceIdentifier,
         max_staleness: u64,
         denom_decimals: u8,
+        config: &Config,
+        price_sources: &Map<&str, OsmosisPriceSourceChecked>,
     ) -> ContractResult<Decimal> {
+        // use current price source for usd
+        let usd_price = price_sources.load(deps.storage, "usd")?.query_price(
+            deps,
+            env,
+            "usd",
+            config,
+            price_sources,
+        )?;
+
         let current_time = env.block.time.seconds();
 
         let price_feed_response = query_price_feed(&deps.querier, contract_addr, price_feed_id)?;
@@ -718,7 +729,7 @@ impl OsmosisPriceSourceChecked {
             current_price.price as u128,
             current_price.expo,
             denom_decimals,
-            config.base_denom_decimals,
+            usd_price,
         )?;
 
         Ok(current_price_dec)
@@ -760,15 +771,20 @@ pub fn scale_pyth_price(
     value: u128,
     expo: i32,
     denom_decimals: u8,
-    base_denom_decimals: u8,
+    usd_price: Decimal,
 ) -> ContractResult<Decimal> {
-    let expo = expo - denom_decimals as i32 + base_denom_decimals as i32;
+    let denom_scaled = Decimal::from_atomics(1u128, denom_decimals as u32)?;
+
     let target_expo = Uint128::from(10u8).checked_pow(expo.unsigned_abs())?;
     if expo < 0 {
-        Ok(Decimal::checked_from_ratio(value, target_expo)?)
+        let pyth_price = Decimal::checked_from_ratio(value, target_expo)?;
+        let price = pyth_price.checked_mul(usd_price)?.checked_mul(denom_scaled)?;
+        Ok(price)
     } else {
         let res = Uint128::from(value).checked_mul(target_expo)?;
-        Ok(Decimal::from_ratio(res, 1u128))
+        let pyth_price = Decimal::from_ratio(res, 1u128);
+        let price = pyth_price.checked_mul(denom_scaled)?.checked_mul(usd_price)?;
+        Ok(price)
     }
 }
 
@@ -781,11 +797,31 @@ mod tests {
     #[test]
     fn scale_real_pyth_price() {
         // ATOM
-        let uatom_price_in_usd = scale_pyth_price(1035200881u128, -8, 6u8, 6u8).unwrap();
-        assert_eq!(uatom_price_in_usd, Decimal::from_str("10.35200881").unwrap());
+        let uatom_price_in_uusd =
+            scale_pyth_price(1035200881u128, -8, 6u8, Decimal::from_str("1000000").unwrap())
+                .unwrap();
+        assert_eq!(uatom_price_in_uusd, Decimal::from_str("10.35200881").unwrap());
 
         // ETH
-        let ueth_price_in_usd = scale_pyth_price(181598000001u128, -8, 18u8, 6u8).unwrap();
-        assert_eq!(ueth_price_in_usd, Decimal::from_str("0.00000000181598").unwrap());
+        let ueth_price_in_uusd =
+            scale_pyth_price(181598000001u128, -8, 18u8, Decimal::from_str("1000000").unwrap())
+                .unwrap();
+        assert_eq!(ueth_price_in_uusd, Decimal::from_str("0.00000000181598").unwrap());
+    }
+
+    #[test]
+    fn scale_pyth_price_if_expo_above_zero() {
+        let ueth_price_in_uusd =
+            scale_pyth_price(181598000001u128, 8, 18u8, Decimal::from_str("1000000").unwrap())
+                .unwrap();
+        assert_eq!(ueth_price_in_uusd, Decimal::from_atomics(181598000001u128, 4u32).unwrap());
+    }
+
+    #[test]
+    fn scale_big_eth_pyth_price() {
+        let ueth_price_in_uusd =
+            scale_pyth_price(100000098000001u128, -8, 18u8, Decimal::from_str("1000000").unwrap())
+                .unwrap();
+        assert_eq!(ueth_price_in_uusd, Decimal::from_atomics(100000098000001u128, 20u32).unwrap());
     }
 }

--- a/contracts/oracle/osmosis/src/stride.rs
+++ b/contracts/oracle/osmosis/src/stride.rs
@@ -2,8 +2,6 @@ use cosmwasm_std::{to_binary, Addr, Decimal, QuerierWrapper, QueryRequest, StdRe
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-// TODO: should be updated once Stride open source their contract
-
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Hash, JsonSchema)]
 pub struct Price {
     pub denom: String,

--- a/contracts/oracle/osmosis/tests/helpers.rs
+++ b/contracts/oracle/osmosis/tests/helpers.rs
@@ -90,7 +90,6 @@ pub fn setup_test() -> OwnedDeps<MockStorage, MockApi, MarsMockQuerier> {
         InstantiateMsg {
             owner: "owner".to_string(),
             base_denom: "uosmo".to_string(),
-            base_denom_decimals: 6u8,
         },
     )
     .unwrap();

--- a/contracts/oracle/osmosis/tests/test_admin.rs
+++ b/contracts/oracle/osmosis/tests/test_admin.rs
@@ -31,7 +31,6 @@ fn instantiating_incorrect_denom() {
         InstantiateMsg {
             owner: "owner".to_string(),
             base_denom: "!*jadfaefc".to_string(),
-            base_denom_decimals: 6u8,
         },
     );
     assert_eq!(
@@ -48,7 +47,6 @@ fn instantiating_incorrect_denom() {
         InstantiateMsg {
             owner: "owner".to_string(),
             base_denom: "ahdbufenf&*!-".to_string(),
-            base_denom_decimals: 6u8,
         },
     );
     assert_eq!(
@@ -66,7 +64,6 @@ fn instantiating_incorrect_denom() {
         InstantiateMsg {
             owner: "owner".to_string(),
             base_denom: "ab".to_string(),
-            base_denom_decimals: 6u8,
         },
     );
     assert_eq!(
@@ -83,7 +80,6 @@ fn update_config_if_unauthorized() {
 
     let msg = ExecuteMsg::UpdateConfig {
         base_denom: None,
-        base_denom_decimals: None,
     };
     let info = mock_info("somebody");
     let res_err = entry::execute(deps.as_mut(), mock_env(), info, msg).unwrap_err();
@@ -96,7 +92,6 @@ fn update_config_with_invalid_base_denom() {
 
     let msg = ExecuteMsg::UpdateConfig {
         base_denom: Some("*!fdskfna".to_string()),
-        base_denom_decimals: None,
     };
     let info = mock_info("owner");
     let res_err = entry::execute(deps.as_mut(), mock_env(), info, msg).unwrap_err();
@@ -114,7 +109,6 @@ fn update_config_with_new_params() {
 
     let msg = ExecuteMsg::UpdateConfig {
         base_denom: Some("uusdc".to_string()),
-        base_denom_decimals: Some(10u8),
     };
     let info = mock_info("owner");
     let res = entry::execute(deps.as_mut(), mock_env(), info, msg).unwrap();
@@ -124,9 +118,7 @@ fn update_config_with_new_params() {
         vec![
             attr("action", "update_config"),
             attr("prev_base_denom", "uosmo"),
-            attr("base_denom", "uusdc"),
-            attr("prev_base_denom_decimals", "6"),
-            attr("base_denom_decimals", "10"),
+            attr("base_denom", "uusdc")
         ]
     );
 
@@ -134,5 +126,4 @@ fn update_config_with_new_params() {
     assert_eq!(cfg.owner.unwrap(), "owner".to_string());
     assert_eq!(cfg.proposed_new_owner, None);
     assert_eq!(cfg.base_denom, "uusdc".to_string());
-    assert_eq!(cfg.base_denom_decimals, 10u8);
 }

--- a/contracts/oracle/osmosis/tests/test_query_price.rs
+++ b/contracts/oracle/osmosis/tests/test_query_price.rs
@@ -1,3 +1,5 @@
+use std::str::FromStr;
+
 use cosmwasm_std::{
     coin, from_binary,
     testing::{MockApi, MockStorage},
@@ -404,6 +406,15 @@ fn querying_staked_geometric_twap_price_with_downtime_detector() {
 fn querying_lsd_price() {
     let mut deps = helpers::setup_test_with_pools();
 
+    // price source used to convert USD to base_denom
+    helpers::set_price_source(
+        deps.as_mut(),
+        "usd",
+        OsmosisPriceSourceUnchecked::Fixed {
+            price: Decimal::from_str("1000000").unwrap(),
+        },
+    );
+
     let publish_time = 1677157333u64;
     let (pyth_price, ustatom_uatom_price) =
         setup_pyth_and_geometric_twap_for_lsd(&mut deps, publish_time);
@@ -515,7 +526,13 @@ fn setup_pyth_and_geometric_twap_for_lsd(
         expo: -4,
         publish_time: publish_time as i64,
     };
-    let pyth_price = scale_pyth_price(price.price as u128, price.expo, 6u8, 6u8).unwrap();
+    let pyth_price = scale_pyth_price(
+        price.price as u128,
+        price.expo,
+        6u8,
+        Decimal::from_str("1000000").unwrap(),
+    )
+    .unwrap();
 
     deps.querier.set_pyth_price(
         price_id,
@@ -673,6 +690,15 @@ fn querying_lsd_price_with_downtime_detector() {
         downtime: Downtime::Duration10m,
         recovery: 360,
     };
+
+    // price source used to convert USD to base_denom
+    helpers::set_price_source(
+        deps.as_mut(),
+        "usd",
+        OsmosisPriceSourceUnchecked::Fixed {
+            price: Decimal::from_str("1000000").unwrap(),
+        },
+    );
 
     // query price if geometric TWAP < redemption rate
     helpers::set_price_source(
@@ -839,6 +865,15 @@ fn querying_xyk_lp_price() {
 fn querying_pyth_price_if_publish_price_too_old() {
     let mut deps = helpers::setup_test();
 
+    // price source used to convert USD to base_denom
+    helpers::set_price_source(
+        deps.as_mut(),
+        "usd",
+        OsmosisPriceSourceUnchecked::Fixed {
+            price: Decimal::from_str("1000000").unwrap(),
+        },
+    );
+
     let price_id = PriceIdentifier::from_hex(
         "61226d39beea19d334f17c2febce27e12646d84675924ebb02b9cdaea68727e3",
     )
@@ -901,6 +936,15 @@ fn querying_pyth_price_if_publish_price_too_old() {
 fn querying_pyth_price_if_signed() {
     let mut deps = helpers::setup_test();
 
+    // price source used to convert USD to base_denom
+    helpers::set_price_source(
+        deps.as_mut(),
+        "usd",
+        OsmosisPriceSourceUnchecked::Fixed {
+            price: Decimal::from_str("1000000").unwrap(),
+        },
+    );
+
     let price_id = PriceIdentifier::from_hex(
         "61226d39beea19d334f17c2febce27e12646d84675924ebb02b9cdaea68727e3",
     )
@@ -959,6 +1003,15 @@ fn querying_pyth_price_if_signed() {
 #[test]
 fn querying_pyth_price_successfully() {
     let mut deps = helpers::setup_test();
+
+    // price source used to convert USD to base_denom
+    helpers::set_price_source(
+        deps.as_mut(),
+        "usd",
+        OsmosisPriceSourceUnchecked::Fixed {
+            price: Decimal::from_str("1000000").unwrap(),
+        },
+    );
 
     let price_id = PriceIdentifier::from_hex(
         "61226d39beea19d334f17c2febce27e12646d84675924ebb02b9cdaea68727e3",

--- a/integration-tests/tests/test_oracles.rs
+++ b/integration-tests/tests/test_oracles.rs
@@ -57,7 +57,6 @@ fn querying_xyk_lp_price_if_no_price_for_tokens() {
         &InstantiateMsg {
             owner: signer.address(),
             base_denom: "uosmo".to_string(),
-            base_denom_decimals: 6u8,
         },
     );
 
@@ -111,7 +110,6 @@ fn querying_xyk_lp_price_success() {
         &InstantiateMsg {
             owner: signer.address(),
             base_denom: "uosmo".to_string(),
-            base_denom_decimals: 6u8,
         },
     );
 
@@ -220,7 +218,6 @@ fn query_spot_price() {
         &InstantiateMsg {
             owner: signer.address(),
             base_denom: "uosmo".to_string(),
-            base_denom_decimals: 6u8,
         },
     );
 
@@ -285,7 +282,6 @@ fn set_spot_without_pools() {
         &InstantiateMsg {
             owner: signer.address(),
             base_denom: "uosmo".to_string(),
-            base_denom_decimals: 6u8,
         },
     );
 
@@ -323,7 +319,6 @@ fn incorrect_pool_for_spot() {
         &InstantiateMsg {
             owner: signer.address(),
             base_denom: "uosmo".to_string(),
-            base_denom_decimals: 6u8,
         },
     );
 
@@ -370,7 +365,6 @@ fn update_spot_with_different_pool() {
         &InstantiateMsg {
             owner: signer.address(),
             base_denom: "uosmo".to_string(),
-            base_denom_decimals: 6u8,
         },
     );
 
@@ -445,7 +439,6 @@ fn query_spot_price_after_lp_change() {
         &InstantiateMsg {
             owner: signer.address(),
             base_denom: "uosmo".to_string(),
-            base_denom_decimals: 6u8,
         },
     );
 
@@ -505,7 +498,6 @@ fn query_geometric_twap_price_with_downtime_detector() {
         &InstantiateMsg {
             owner: signer.address(),
             base_denom: "uosmo".to_string(),
-            base_denom_decimals: 6u8,
         },
     );
 
@@ -590,7 +582,6 @@ fn query_arithmetic_twap_price() {
         &InstantiateMsg {
             owner: signer.address(),
             base_denom: "uosmo".to_string(),
-            base_denom_decimals: 6u8,
         },
     );
 
@@ -677,7 +668,6 @@ fn query_geometric_twap_price() {
         &InstantiateMsg {
             owner: signer.address(),
             base_denom: "uosmo".to_string(),
-            base_denom_decimals: 6u8,
         },
     );
 
@@ -764,7 +754,6 @@ fn compare_spot_and_twap_price() {
         &InstantiateMsg {
             owner: signer.address(),
             base_denom: "uosmo".to_string(),
-            base_denom_decimals: 6u8,
         },
     );
 
@@ -1025,7 +1014,6 @@ fn setup_redbank(wasm: &Wasm<OsmosisTestApp>, signer: &SigningAccount) -> (Strin
         &InstantiateMsg {
             owner: signer.address(),
             base_denom: "uosmo".to_string(),
-            base_denom_decimals: 6u8,
         },
     );
 

--- a/packages/testing/src/integration/mock_env.rs
+++ b/packages/testing/src/integration/mock_env.rs
@@ -615,7 +615,6 @@ impl MockEnvBuilder {
                 &oracle::InstantiateMsg {
                     owner: self.owner.to_string(),
                     base_denom: self.base_denom.clone(),
-                    base_denom_decimals: self.base_denom_decimals,
                 },
                 &[],
                 "oracle",

--- a/packages/types/src/oracle.rs
+++ b/packages/types/src/oracle.rs
@@ -8,16 +8,12 @@ pub struct InstantiateMsg {
     pub owner: String,
     /// The asset in which prices are denominated in
     pub base_denom: String,
-    /// The asset decimals used for price normalization
-    pub base_denom_decimals: u8,
 }
 
 #[cw_serde]
 pub struct Config {
     /// The asset in which prices are denominated in
     pub base_denom: String,
-    /// The asset decimals used for price normalization
-    pub base_denom_decimals: u8,
 }
 
 #[cw_serde]
@@ -38,7 +34,6 @@ pub enum ExecuteMsg<T> {
     /// Update contract config (only callable by owner)
     UpdateConfig {
         base_denom: Option<String>,
-        base_denom_decimals: Option<u8>,
     },
 }
 
@@ -90,8 +85,6 @@ pub struct ConfigResponse {
     pub proposed_new_owner: Option<String>,
     /// The asset in which prices are denominated in
     pub base_denom: String,
-    /// The asset decimals used for price normalization
-    pub base_denom_decimals: u8,
 }
 
 #[cw_serde]

--- a/schemas/mars-oracle-osmosis/mars-oracle-osmosis.json
+++ b/schemas/mars-oracle-osmosis/mars-oracle-osmosis.json
@@ -8,19 +8,12 @@
     "type": "object",
     "required": [
       "base_denom",
-      "base_denom_decimals",
       "owner"
     ],
     "properties": {
       "base_denom": {
         "description": "The asset in which prices are denominated in",
         "type": "string"
-      },
-      "base_denom_decimals": {
-        "description": "The asset decimals used for price normalization",
-        "type": "integer",
-        "format": "uint8",
-        "minimum": 0.0
       },
       "owner": {
         "description": "The contract's owner, who can update config and price sources",
@@ -109,14 +102,6 @@
                   "string",
                   "null"
                 ]
-              },
-              "base_denom_decimals": {
-                "type": [
-                  "integer",
-                  "null"
-                ],
-                "format": "uint8",
-                "minimum": 0.0
               }
             },
             "additionalProperties": false
@@ -437,7 +422,7 @@
                     "type": "string"
                   },
                   "denom_decimals": {
-                    "description": "Assets are represented in their smallest unit and every asset can have different decimals (e.g. OSMO - 6 decimals, WETH - 18 decimals).\n\nPyth prices are denominated in USD so basically it means how much 1 USDC, 1 ATOM, 1 OSMO is worth in USD (NOT 1 uusdc, 1 uatom, 1 uosmo). We have to normalize it. We should get how much 1 utoken is worth in uusd. For example: denom_decimals (OSMO) = 6 base_denom_decimals (USD) = 6\n\n1 OSMO = 10^6 uosmo 1 USD = 10^6 uusd\n\nosmo_price_in_usd = 0.59958994 uosmo_price_in_uusd = osmo_price_in_usd / 10^denom_decimals * 10^base_denom_decimals = uosmo_price_in_uusd = 0.59958994 * 10^(-6) * 10^6 = 0.59958994",
+                    "description": "Assets are represented in their smallest unit and every asset can have different decimals (e.g. OSMO - 6 decimals, WETH - 18 decimals).\n\nPyth prices are denominated in USD so basically it means how much 1 USDC, 1 ATOM, 1 OSMO is worth in USD (NOT 1 uusdc, 1 uatom, 1 uosmo). We have to normalize it. We should get how much 1 utoken is worth in uusd. For example: - base_denom = uusd - price source set for usd (e.g. FIXED price source where 1 usd = 1000000 uusd) - denom_decimals (ATOM) = 6\n\n1 OSMO = 10^6 uosmo\n\nosmo_price_in_usd = 0.59958994 uosmo_price_in_uusd = osmo_price_in_usd * usd_price_in_base_denom / 10^denom_decimals = uosmo_price_in_uusd = 0.59958994 * 1000000 * 10^(-6) = 0.59958994",
                     "type": "integer",
                     "format": "uint8",
                     "minimum": 0.0
@@ -449,7 +434,7 @@
                     "minimum": 0.0
                   },
                   "price_feed_id": {
-                    "description": "Price feed id of an asset from the list: https://pyth.network/developers/price-feed-ids",
+                    "description": "Price feed id of an asset from the list: https://pyth.network/developers/price-feed-ids We can't verify what denoms consist of the price feed. Be very careful when adding it !!!",
                     "allOf": [
                       {
                         "$ref": "#/definitions/Identifier"
@@ -703,19 +688,12 @@
       "title": "ConfigResponse",
       "type": "object",
       "required": [
-        "base_denom",
-        "base_denom_decimals"
+        "base_denom"
       ],
       "properties": {
         "base_denom": {
           "description": "The asset in which prices are denominated in",
           "type": "string"
-        },
-        "base_denom_decimals": {
-          "description": "The asset decimals used for price normalization",
-          "type": "integer",
-          "format": "uint8",
-          "minimum": 0.0
         },
         "owner": {
           "description": "The contract's owner",

--- a/scripts/types/generated/mars-oracle-osmosis/MarsOracleOsmosis.client.ts
+++ b/scripts/types/generated/mars-oracle-osmosis/MarsOracleOsmosis.client.ts
@@ -140,10 +140,8 @@ export interface MarsOracleOsmosisInterface extends MarsOracleOsmosisReadOnlyInt
   updateConfig: (
     {
       baseDenom,
-      baseDenomDecimals,
     }: {
       baseDenom?: string
-      baseDenomDecimals?: number
     },
     fee?: number | StdFee | 'auto',
     memo?: string,
@@ -237,10 +235,8 @@ export class MarsOracleOsmosisClient
   updateConfig = async (
     {
       baseDenom,
-      baseDenomDecimals,
     }: {
       baseDenom?: string
-      baseDenomDecimals?: number
     },
     fee: number | StdFee | 'auto' = 'auto',
     memo?: string,
@@ -252,7 +248,6 @@ export class MarsOracleOsmosisClient
       {
         update_config: {
           base_denom: baseDenom,
-          base_denom_decimals: baseDenomDecimals,
         },
       },
       fee,

--- a/scripts/types/generated/mars-oracle-osmosis/MarsOracleOsmosis.react-query.ts
+++ b/scripts/types/generated/mars-oracle-osmosis/MarsOracleOsmosis.react-query.ts
@@ -171,7 +171,6 @@ export interface MarsOracleOsmosisUpdateConfigMutation {
   client: MarsOracleOsmosisClient
   msg: {
     baseDenom?: string
-    baseDenomDecimals?: number
   }
   args?: {
     fee?: number | StdFee | 'auto'

--- a/scripts/types/generated/mars-oracle-osmosis/MarsOracleOsmosis.types.ts
+++ b/scripts/types/generated/mars-oracle-osmosis/MarsOracleOsmosis.types.ts
@@ -7,7 +7,6 @@
 
 export interface InstantiateMsg {
   base_denom: string
-  base_denom_decimals: number
   owner: string
 }
 export type ExecuteMsg =
@@ -28,7 +27,6 @@ export type ExecuteMsg =
   | {
       update_config: {
         base_denom?: string | null
-        base_denom_decimals?: number | null
       }
     }
 export type OsmosisPriceSourceForString =
@@ -173,7 +171,6 @@ export type QueryMsg =
     }
 export interface ConfigResponse {
   base_denom: string
-  base_denom_decimals: number
   owner?: string | null
   proposed_new_owner?: string | null
 }


### PR DESCRIPTION
Some inspiration from @apollo-sturdy review in previous PR.
```
Math looks correct to me. But now reading this I'm not so sure that adding decimals for base_denom is the best idea as it is now only used for conversion with USD, which assumes base_denom is scaled USD? In fact, with the addition of this implementation, base_denom must be some scaled version of whatever denom all added pyth prices use. Maybe a better idea would be to do like we did for Astroport and have route_assets? This way we can support any base denom and also any pyth price feed that is not denominated in USD.

This way you could still have base_denom be for example uusd and you would have for pyth assets route_assets = ['USD'], were price source for USD/uusd would be 1000000.
```

This way we can convert pyth USD to different `base_denom`. It can be uusd, uosmo, untrn etc. We only need price source for USD.
IMO `route_assets` don't make sense because all our prices are denominated in the same denom so having route like ["USD", "UOSMO"] (assume that base_denom=uosmo) could end up multiplying `pyth_price_in_USD * usd_price_in_uosmo * uosmo_in_uosmo`.