### PR TITLE
Disable grcov coverage

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -33,11 +33,15 @@ jobs:
       - name: Compile workspace
         run: cargo make build
 
-      - name: Run test coverage
-        run: cargo make coverage-lcov
+      - name: Run test
+        run: cargo make test
 
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: target/coverage/lcov.info
+      # disabled because of "no space left" error.
+      # - name: Run test coverage
+      #   run: cargo make coverage-lcov
+
+      # - name: Upload coverage to Codecov
+      #   uses: codecov/codecov-action@v3
+      #   with:
+      #     token: ${{ secrets.CODECOV_TOKEN }}
+      #     files: target/coverage/lcov.info

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -21,6 +21,7 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profil
 rustup target add wasm32-unknown-unknown --toolchain ${RUST_VERSION}
 rustup component add rustfmt --toolchain ${RUST_VERSION}
 rustup component add clippy --toolchain ${RUST_VERSION}
+rustup component add llvm-tools-preview --toolchain ${RUST_VERSION}
 '''
 
 [tasks.install-nightly]

--- a/coverage_grcov.Makefile.toml
+++ b/coverage_grcov.Makefile.toml
@@ -22,7 +22,6 @@ run_task = "test"
 
 [tasks.coverage-grcov-run-test.env]
 CARGO_BUILD_TARGET_DIR = "${COVERAGE_TARGET_DIRECTORY}"
-CARGO_INCREMENTAL = "0"
 RUSTFLAGS = "-Cinstrument-coverage"
 LLVM_PROFILE_FILE = "${COVERAGE_PROF_OUTPUT}/coverage-%p-%m.profraw"
 


### PR DESCRIPTION
Disable grcov coverage. It blocks CI with `no space left` or `timeout`. This requires more investigation so for now disabling coverage in CI.