### PR TITLE
Clean up

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -527,9 +527,12 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.79"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+checksum = "305fe645edc1442a0fa8b6726ba61d422798d37a52e12eaecf4b022ebbb88f01"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "cexpr"
@@ -1897,7 +1900,7 @@ dependencies = [
 
 [[package]]
 name = "mars-params"
-version = "1.0.7"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",
@@ -1910,8 +1913,6 @@ dependencies = [
  "mars-red-bank-types",
  "mars-testing",
  "mars-utils",
- "schemars",
- "serde",
  "test-case",
  "thiserror",
 ]
@@ -1959,12 +1960,9 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-storage-plus 1.1.0",
- "mars-osmosis",
  "mars-owner",
  "mars-red-bank-types",
- "mars-testing",
  "mars-utils",
- "osmosis-std",
  "schemars",
  "serde",
  "thiserror",
@@ -1974,30 +1972,18 @@ dependencies = [
 name = "mars-rewards-collector-neutron"
 version = "1.2.0"
 dependencies = [
- "cosmwasm-schema",
  "cosmwasm-std",
- "cw-storage-plus 1.1.0",
  "cw2 1.1.0",
- "mars-osmosis",
- "mars-owner",
  "mars-red-bank-types",
  "mars-rewards-collector-base",
- "mars-testing",
- "mars-utils",
  "neutron-sdk",
- "osmosis-std",
- "schemars",
- "serde",
- "thiserror",
 ]
 
 [[package]]
 name = "mars-rewards-collector-osmosis"
 version = "1.2.0"
 dependencies = [
- "cosmwasm-schema",
  "cosmwasm-std",
- "cw-storage-plus 1.1.0",
  "cw2 1.1.0",
  "mars-osmosis",
  "mars-owner",
@@ -2006,9 +1992,7 @@ dependencies = [
  "mars-testing",
  "mars-utils",
  "osmosis-std",
- "schemars",
  "serde",
- "thiserror",
 ]
 
 [[package]]
@@ -2047,9 +2031,7 @@ dependencies = [
 name = "mars-swapper-mock"
 version = "1.2.0"
 dependencies = [
- "anyhow",
  "cosmwasm-std",
- "cw-multi-test",
  "mars-red-bank-types",
 ]
 
@@ -2409,18 +2391,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "030ad2bc4db10a8944cb0d837f158bdfec4d4a4873ab701a95046770d11f8842"
+checksum = "fda4ed1c6c173e3fc7a83629421152e01d7b1f9b7f65fb301e490e8cfc656422"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec2e072ecce94ec471b13398d5402c188e76ac03cf74dd1a975161b23a3f6d9c"
+checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2429,9 +2411,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c40d25201921e5ff0c862a505c6557ea88568a4e3ace775ab55e93f2f4f9d57"
+checksum = "2c516611246607d0c04186886dbb3a754368ef82c79e9827a802c6d836dd111c"
 
 [[package]]
 name = "pin-utils"
@@ -2698,9 +2680,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.9.1"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2eae68fc220f7cf2532e4494aded17545fce192d59cd996e0fe7887f4ceb575"
+checksum = "81bc1d4caf89fac26a70747fe603c130093b53c773888797a6329091246d651a"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2710,9 +2692,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.3.4"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7b6d6190b7594385f61bd3911cd1be99dfddcfc365a4160cc2ab5bff4aed294"
+checksum = "fed1ceff11a1dddaee50c9dc8e4938bd106e9d89ae372f192311e7da498e3b69"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2812,9 +2794,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"
-version = "0.38.4"
+version = "0.38.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a962918ea88d644592894bc6dc55acc6c0956488adcebbfb6e273506b7fd6e5"
+checksum = "172891ebdceb05aa0005f533a6cbfca599ddd7d966f6f5d4d9b2e70478e70399"
 dependencies = [
  "bitflags 2.3.3",
  "errno",
@@ -2969,9 +2951,9 @@ checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
 
 [[package]]
 name = "serde"
-version = "1.0.181"
+version = "1.0.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d3e73c93c3240c0bda063c239298e633114c69a888c3e37ca8bb33f343e9890"
+checksum = "32ac8da02677876d532745a130fc9d8e6edfa81a269b107c5b00829b91d8eb3c"
 dependencies = [
  "serde_derive",
 ]
@@ -3005,9 +2987,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.181"
+version = "1.0.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be02f6cb0cd3a5ec20bbcfbcbd749f57daddb1a0882dc2e46a6c236c90b977ed"
+checksum = "aafe972d60b0b9bee71a91b92fee2d4fb3c9d7e8f6b179aa99f27203d99a4816"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3191,7 +3173,7 @@ version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
 dependencies = [
- "strum_macros 0.25.1",
+ "strum_macros 0.25.2",
 ]
 
 [[package]]
@@ -3209,9 +3191,9 @@ dependencies = [
 
 [[package]]
 name = "strum_macros"
-version = "0.25.1"
+version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6069ca09d878a33f883cc06aaa9718ede171841d3832450354410b718b097232"
+checksum = "ad8d03b598d3d0fff69bf533ee3ef19b8eeb342729596df84bcc7e1f96ec4059"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -3259,9 +3241,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.7.0"
+version = "3.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5486094ee78b2e5038a6382ed7645bc084dc2ec433426ca4c3cb61e2007b8998"
+checksum = "dc02fddf48964c42031a0b3fe0428320ecf3a73c401040fc0096f97794310651"
 dependencies = [
  "cfg-if",
  "fastrand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,44 +30,39 @@ authors       = [
   "Ahmad Kaouk",
   "Harry Scholes",
 ]
-edition = "2021"
-license = "GPL-3.0-or-later"
-repository = "https://github.com/mars-protocol/red-bank"
-homepage = "https://marsprotocol.io"
+edition       = "2021"
+license       = "GPL-3.0-or-later"
+repository    = "https://github.com/mars-protocol/red-bank"
+homepage      = "https://marsprotocol.io"
 documentation = "https://docs.marsprotocol.io/"
-keywords = [
-  "mars",
-  "cosmos",
-  "cosmwasm",
-]
+keywords      = ["mars", "cosmos", "cosmwasm"]
 
 [workspace.dependencies]
 anyhow            = "1.0.72"
+astroport         = "2.8.0"
 bech32            = "0.9.1"
 cosmwasm-schema   = "1.3.1"
 cosmwasm-std      = "1.3.1"
 cw2               = "1.1.0"
+cw-paginate       = "0.2.1"
 cw-storage-plus   = "1.1.0"
 cw-utils          = "1.0.1"
 mars-owner        = { version = "2.0.0", features = ["emergency-owner"] }
-osmosis-std       = "0.16.1"
-prost             = { version = "0.11.9", default-features = false, features = ["prost-derive"] }
-schemars          = "0.8.12"
-serde             = { version = "1.0.181", default-features = false, features = ["derive"] }
-thiserror         = "1.0.44"
-pyth-sdk-cw       = "1.2.0"
-cw-paginate       = "0.2.1"
-astroport         = "2.8.0"
-strum             = "0.25.0"
 neutron-sdk       = "0.6.1"
-serde_json        = "1.0"
+osmosis-std       = "0.16.1"
+prost             = { version = "0.11.9", default-features = false }
+pyth-sdk-cw       = "1.2.0"
+schemars          = "0.8.12"
+serde             = { version = "1.0.181", default-features = false }
+strum             = "0.25.0"
+thiserror         = "1.0.44"
 
 # dev-dependencies
 cw-multi-test     = "0.16.5"
 cw-it             = "0.1.0"
 osmosis-test-tube = "=16.1.1"
-test-case         = "3.1.0"
 proptest          = "1.2.0"
+test-case         = "3.1.0"
 
 # packages
 mars-health         = { path = "./packages/health" }
@@ -88,9 +83,10 @@ mars-oracle-wasm               = { path = "./contracts/oracle/wasm" }
 mars-params                    = { path = "./contracts/params" }
 mars-red-bank                  = { path = "./contracts/red-bank" }
 mars-rewards-collector-base    = { path = "./contracts/rewards-collector/base" }
+mars-rewards-collector-neutron = { path = "./contracts/rewards-collector/neutron" }
 mars-rewards-collector-osmosis = { path = "./contracts/rewards-collector/osmosis" }
-mars-swapper-base              = { path = "./contracts/swapper/base" }
 mars-swapper-astroport         = { path = "./contracts/swapper/astroport" }
+mars-swapper-base              = { path = "./contracts/swapper/base" }
 mars-swapper-osmosis           = { path = "./contracts/swapper/osmosis" }
 
 [profile.release]

--- a/contracts/address-provider/Cargo.toml
+++ b/contracts/address-provider/Cargo.toml
@@ -11,22 +11,13 @@ documentation = { workspace = true }
 keywords      = { workspace = true }
 
 [lib]
-crate-type = [
-    "cdylib",
-    "rlib",
-]
-doctest = false
-
-[profile.release]
-overflow-checks  = true
+crate-type = ["cdylib", "rlib"]
+doctest    = false
 
 [features]
 # for more explicit tests, cargo test --features=backtraces
-backtraces = [
-    "cosmwasm-std/backtraces",
-]
-library = [
-]
+backtraces = ["cosmwasm-std/backtraces"]
+library    = []
 
 [dependencies]
 bech32              = { workspace = true }

--- a/contracts/incentives/Cargo.toml
+++ b/contracts/incentives/Cargo.toml
@@ -12,10 +12,7 @@ keywords      = { workspace = true }
 
 [lib]
 crate-type = ["cdylib", "rlib"]
-doctest = false
-
-[profile.release]
-overflow-checks  = true
+doctest    = false
 
 [features]
 # for more explicit tests, cargo test --features=backtraces

--- a/contracts/mock-pyth/Cargo.toml
+++ b/contracts/mock-pyth/Cargo.toml
@@ -12,6 +12,7 @@ keywords      = { workspace = true }
 
 [lib]
 crate-type = ["cdylib", "rlib"]
+doctest    = false
 
 [features]
 # for quicker tests, cargo test --lib

--- a/contracts/oracle/base/Cargo.toml
+++ b/contracts/oracle/base/Cargo.toml
@@ -12,13 +12,10 @@ keywords      = { workspace = true }
 [lib]
 doctest = false
 
-[profile.release]
-overflow-checks  = true
-
 [features]
-pyth        = ["pyth-sdk-cw"]
 # for more explicit tests, cargo test --features=backtraces
 backtraces  = ["cosmwasm-std/backtraces"]
+pyth        = ["pyth-sdk-cw"]
 
 [dependencies]
 cosmwasm-std        = { workspace = true }
@@ -26,7 +23,7 @@ cw2                 = { workspace = true }
 cw-storage-plus     = { workspace = true }
 mars-owner          = { workspace = true }
 mars-red-bank-types = { workspace = true }
+pyth-sdk-cw         = { workspace = true, optional = true }
 schemars            = { workspace = true }
 serde               = { workspace = true }
 thiserror           = { workspace = true }
-pyth-sdk-cw         = { workspace = true, optional = true }

--- a/contracts/oracle/osmosis/Cargo.toml
+++ b/contracts/oracle/osmosis/Cargo.toml
@@ -12,10 +12,7 @@ keywords      = { workspace = true }
 
 [lib]
 crate-type = ["cdylib", "rlib"]
-doctest = false
-
-[profile.release]
-overflow-checks  = true
+doctest    = false
 
 [features]
 # for more explicit tests, cargo test --features=backtraces
@@ -26,9 +23,9 @@ cosmwasm-schema     = { workspace = true }
 cosmwasm-std        = { workspace = true }
 cw2                 = { workspace = true }
 cw-storage-plus     = { workspace = true }
-mars-owner          = { workspace = true }
 mars-oracle-base    = { workspace = true, features = ["pyth"] }
 mars-osmosis        = { workspace = true }
+mars-owner          = { workspace = true }
 mars-red-bank-types = { workspace = true }
 osmosis-std         = { workspace = true }
 pyth-sdk-cw         = { workspace = true }
@@ -37,7 +34,7 @@ serde               = { workspace = true }
 
 [dev-dependencies]
 cosmwasm-schema = { workspace = true }
-mars-testing    = { workspace = true }
 mars-owner      = { workspace = true }
+mars-testing    = { workspace = true }
 mars-utils      = { workspace = true }
 pyth-sdk-cw     = { workspace = true }

--- a/contracts/oracle/wasm/Cargo.toml
+++ b/contracts/oracle/wasm/Cargo.toml
@@ -14,29 +14,26 @@ keywords      = { workspace = true }
 crate-type = ["cdylib", "rlib"]
 doctest    = false
 
-[profile.release]
-overflow-checks  = true
-
 [features]
 # for more explicit tests, cargo test --features=backtraces
-backtraces = ["cosmwasm-std/backtraces"]
-library = []
+backtraces       = ["cosmwasm-std/backtraces"]
+library          = []
 osmosis-test-app = ["cw-it/osmosis-test-tube", "mars-testing/osmosis-test-tube"]
 
 [dependencies]
+astroport               = { workspace = true }
+cosmwasm-schema         = { workspace = true }
 cosmwasm-std            = { workspace = true }
 cw2                     = { workspace = true }
 cw-storage-plus         = { workspace = true }
 mars-oracle-base        = { workspace = true, features = ["pyth"] }
 mars-red-bank-types     = { workspace = true }
-cosmwasm-schema         = { workspace = true }
-astroport               = { workspace = true }
 pyth-sdk-cw             = { workspace = true }
 
 [dev-dependencies]
 cosmwasm-schema  = { workspace = true }
-mars-testing     = { workspace = true, features = ["astroport"] }
-mars-owner       = { workspace = true }
 cw-it            = { workspace = true, features = ["astroport", "astroport-multi-test"] }
-test-case        = { workspace = true }
+mars-owner       = { workspace = true }
+mars-testing     = { workspace = true, features = ["astroport"] }
 proptest         = { workspace = true }
+test-case        = { workspace = true }

--- a/contracts/params/Cargo.toml
+++ b/contracts/params/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name          = "mars-params"
 description   = "Contract storing the asset params for Credit Manager and Red Bank."
-version       = "1.0.7"
+version       = { workspace = true }
 authors       = { workspace = true }
 license       = { workspace = true }
 edition       = { workspace = true }
@@ -12,6 +12,7 @@ keywords      = { workspace = true }
 
 [lib]
 crate-type = ["cdylib", "rlib"]
+doctest    = false
 
 [features]
 # for quicker tests, cargo test --lib
@@ -28,8 +29,6 @@ mars-interest-rate  = { workspace = true }
 mars-owner          = { workspace = true }
 mars-red-bank-types = { workspace = true }
 mars-utils          = { workspace = true }
-schemars            = { workspace = true }
-serde               = { workspace = true }
 thiserror           = { workspace = true }
 
 [dev-dependencies]

--- a/contracts/red-bank/Cargo.toml
+++ b/contracts/red-bank/Cargo.toml
@@ -12,10 +12,7 @@ keywords      = { workspace = true }
 
 [lib]
 crate-type = ["cdylib", "rlib"]
-doctest = false
-
-[profile.release]
-overflow-checks  = true
+doctest    = false
 
 [features]
 # for more explicit tests, cargo test --features=backtraces
@@ -33,8 +30,8 @@ mars-owner          = { workspace = true }
 mars-params         = { workspace = true }
 mars-red-bank-types = { workspace = true }
 mars-utils          = { workspace = true }
-thiserror           = { workspace = true }
 pyth-sdk-cw         = { workspace = true }
+thiserror           = { workspace = true }
 
 [dev-dependencies]
 anyhow          = { workspace = true }

--- a/contracts/rewards-collector/base/Cargo.toml
+++ b/contracts/rewards-collector/base/Cargo.toml
@@ -10,20 +10,12 @@ documentation = { workspace = true }
 keywords      = { workspace = true }
 
 [lib]
-crate-type = [
-    "cdylib",
-    "rlib",
-]
-doctest = false
-
-[profile.release]
-overflow-checks  = true
+crate-type = ["cdylib", "rlib"]
+doctest    = false
 
 [features]
 # for more explicit tests, cargo test --features=backtraces
-backtraces = [
-    "cosmwasm-std/backtraces",
-]
+backtraces = ["cosmwasm-std/backtraces"]
 
 [dependencies]
 cosmwasm-schema     = { workspace = true }
@@ -35,8 +27,3 @@ mars-utils          = { workspace = true }
 schemars            = { workspace = true }
 serde               = { workspace = true }
 thiserror           = { workspace = true }
-
-[dev-dependencies]
-mars-osmosis = { workspace = true }
-mars-testing = { workspace = true }
-osmosis-std  = { workspace = true }

--- a/contracts/rewards-collector/neutron/Cargo.toml
+++ b/contracts/rewards-collector/neutron/Cargo.toml
@@ -10,36 +10,16 @@ documentation = { workspace = true }
 keywords      = { workspace = true }
 
 [lib]
-crate-type = [
-    "cdylib",
-    "rlib",
-]
-doctest = false
-
-[profile.release]
-overflow-checks  = true
+crate-type = ["cdylib", "rlib"]
+doctest    = false
 
 [features]
 # for more explicit tests, cargo test --features=backtraces
-backtraces = [
-    "cosmwasm-std/backtraces",
-]
+backtraces = ["cosmwasm-std/backtraces"]
 
 [dependencies]
-cosmwasm-schema                 = { workspace = true }
-cosmwasm-std                    = { workspace = true, features = ["stargate"] }
-cw2                             = { workspace = true }
-cw-storage-plus                 = { workspace = true }
-mars-owner                      = { workspace = true }
-mars-red-bank-types             = { workspace = true }
-mars-rewards-collector-base     = { workspace = true }
-mars-utils                      = { workspace = true }
-schemars                        = { workspace = true }
-serde                           = { workspace = true }
-thiserror                       = { workspace = true }
-neutron-sdk                     = { workspace = true }
-
-[dev-dependencies]
-mars-osmosis = { workspace = true }
-mars-testing = { workspace = true }
-osmosis-std  = { workspace = true }
+cosmwasm-std                = { workspace = true, features = ["stargate"] }
+cw2                         = { workspace = true }
+mars-red-bank-types         = { workspace = true }
+mars-rewards-collector-base = { workspace = true }
+neutron-sdk                 = { workspace = true }

--- a/contracts/rewards-collector/osmosis/Cargo.toml
+++ b/contracts/rewards-collector/osmosis/Cargo.toml
@@ -10,35 +10,23 @@ documentation = { workspace = true }
 keywords      = { workspace = true }
 
 [lib]
-crate-type = [
-    "cdylib",
-    "rlib",
-]
-doctest = false
-
-[profile.release]
-overflow-checks  = true
+crate-type = ["cdylib", "rlib"]
+doctest    = false
 
 [features]
 # for more explicit tests, cargo test --features=backtraces
-backtraces = [
-    "cosmwasm-std/backtraces",
-]
+backtraces = ["cosmwasm-std/backtraces"]
 
 [dependencies]
-cosmwasm-schema                 = { workspace = true }
-cosmwasm-std                    = { workspace = true, features = ["stargate"] }
-cw2                             = { workspace = true }
-cw-storage-plus                 = { workspace = true }
-mars-owner                      = { workspace = true }
-mars-red-bank-types             = { workspace = true }
-mars-rewards-collector-base     = { workspace = true }
-mars-utils                      = { workspace = true }
-schemars                        = { workspace = true }
-serde                           = { workspace = true }
-thiserror                       = { workspace = true }
+cosmwasm-std                = { workspace = true, features = ["stargate"] }
+cw2                         = { workspace = true }
+mars-red-bank-types         = { workspace = true }
+mars-rewards-collector-base = { workspace = true }
 
 [dev-dependencies]
 mars-osmosis = { workspace = true }
+mars-owner   = { workspace = true }
 mars-testing = { workspace = true }
+mars-utils   = { workspace = true }
 osmosis-std  = { workspace = true }
+serde        = { workspace = true }

--- a/contracts/swapper/astroport/Cargo.toml
+++ b/contracts/swapper/astroport/Cargo.toml
@@ -11,29 +11,27 @@ keywords      = { workspace = true }
 
 [lib]
 crate-type = ["cdylib", "rlib"]
-
-[profile.release]
-overflow-checks  = true
+doctest    = false
 
 [features]
-default = []
 # for quicker tests, cargo test --lib
 # for more explicit tests, cargo test --features=backtraces
-backtraces = ["cosmwasm-std/backtraces"]
-library    = []
+backtraces        = ["cosmwasm-std/backtraces"]
+default           = []
+library           = []
 osmosis-test-tube = ["cw-it/osmosis-test-tube", "mars-testing/osmosis-test-tube"]
 
 [dependencies]
+astroport           = { workspace = true }
 cosmwasm-schema     = { workspace = true }
 cosmwasm-std        = { workspace = true }
 cw2                 = { workspace = true }
-mars-swapper-base   = { workspace = true }
-mars-oracle-wasm    = { workspace = true }
 mars-red-bank-types = { workspace = true }
-astroport           = { workspace = true }
+mars-swapper-base   = { workspace = true }
 
 [dev-dependencies]
 anyhow            = { workspace = true }
-mars-testing      = { workspace = true, features = ["astroport"] }
 cw-it             = { workspace = true, features = ["astroport", "astroport-multi-test"] }
-test-case         = "3.0.0"
+mars-oracle-wasm  = { workspace = true }
+mars-testing      = { workspace = true, features = ["astroport"] }
+test-case         = { workspace = true }

--- a/contracts/swapper/base/Cargo.toml
+++ b/contracts/swapper/base/Cargo.toml
@@ -10,10 +10,7 @@ documentation = { workspace = true }
 keywords      = { workspace = true }
 
 [lib]
-crate-type = ["cdylib", "rlib"]
-
-[profile.release]
-overflow-checks  = true
+doctest = false
 
 [features]
 # for quicker tests, cargo test --lib

--- a/contracts/swapper/mock/Cargo.toml
+++ b/contracts/swapper/mock/Cargo.toml
@@ -11,6 +11,7 @@ keywords      = { workspace = true }
 
 [lib]
 crate-type = ["cdylib", "rlib"]
+doctest    = false
 
 [features]
 # for quicker tests, cargo test --lib
@@ -21,7 +22,3 @@ library    = []
 [dependencies]
 cosmwasm-std        = { workspace = true }
 mars-red-bank-types = { workspace = true }
-
-[dev-dependencies]
-anyhow        = { workspace = true }
-cw-multi-test = { workspace = true }

--- a/contracts/swapper/osmosis/Cargo.toml
+++ b/contracts/swapper/osmosis/Cargo.toml
@@ -11,9 +11,7 @@ keywords      = { workspace = true }
 
 [lib]
 crate-type = ["cdylib", "rlib"]
-
-[profile.release]
-overflow-checks  = true
+doctest    = false
 
 [features]
 # for quicker tests, cargo test --lib
@@ -32,5 +30,5 @@ osmosis-std         = { workspace = true }
 mars-red-bank-types = { workspace = true }
 
 [dev-dependencies]
-anyhow            = { workspace = true }
-cw-it             = { workspace = true, features = ["osmosis-test-tube"] }
+anyhow = { workspace = true }
+cw-it  = { workspace = true, features = ["osmosis-test-tube"] }

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -10,34 +10,28 @@ documentation = { workspace = true }
 keywords      = { workspace = true }
 
 [lib]
-crate-type = [
-    "cdylib",
-    "rlib",
-]
 doctest = false
 
 [features]
 # for more explicit tests, cargo test --features=backtraces
-backtraces = [
-    "cosmwasm-std/backtraces",
-]
+backtraces = ["cosmwasm-std/backtraces"]
 
 [dev-dependencies]
 anyhow                         = { workspace = true }
 cosmwasm-std                   = { workspace = true }
-cw-multi-test                  = { workspace = true }
 cw-it                          = { workspace = true, features = ["osmosis-test-tube"] }
+cw-multi-test                  = { workspace = true }
 mars-incentives                = { workspace = true }
-mars-oracle-osmosis            = { workspace = true }
 mars-oracle-base               = { workspace = true }
+mars-oracle-osmosis            = { workspace = true }
 mars-osmosis                   = { workspace = true }
 mars-params                    = { workspace = true }
 mars-red-bank                  = { workspace = true }
 mars-red-bank-types            = { workspace = true }
 mars-rewards-collector-osmosis = { workspace = true }
+mars-swapper-osmosis           = { workspace = true }
 mars-testing                   = { workspace = true }
 mars-utils                     = { workspace = true }
 osmosis-std                    = { workspace = true }
 osmosis-test-tube              = { workspace = true }
 serde                          = { workspace = true }
-mars-swapper-osmosis           = { workspace = true }

--- a/packages/liquidation/Cargo.toml
+++ b/packages/liquidation/Cargo.toml
@@ -19,7 +19,7 @@ doctest = false
 backtraces = ["cosmwasm-std/backtraces"]
 
 [dependencies]
-cosmwasm-std        = { workspace = true }
-mars-health         = { workspace = true }
-mars-params         = { workspace = true }
-thiserror           = { workspace = true }
+cosmwasm-std = { workspace = true }
+mars-health  = { workspace = true }
+mars-params  = { workspace = true }
+thiserror    = { workspace = true }

--- a/packages/testing/Cargo.toml
+++ b/packages/testing/Cargo.toml
@@ -14,12 +14,10 @@ keywords      = { workspace = true }
 doctest = false
 
 [features]
-default = []
-# for quicker tests, cargo test --lib
-# for more explicit tests, cargo test --features=backtraces
-astroport = ["cw-it/astroport", "dep:astroport"]
+astroport         = ["cw-it/astroport", "dep:astroport"]
+backtraces        = ["cosmwasm-std/backtraces", "osmosis-std/backtraces"]
+default           = []
 osmosis-test-tube = ["cw-it/osmosis-test-tube"]
-backtraces = ["cosmwasm-std/backtraces", "osmosis-std/backtraces"]
 
 [dependencies]
 anyhow                         = { workspace = true }
@@ -42,7 +40,6 @@ mars-swapper-astroport         = { workspace = true }
 prost                          = { workspace = true }
 pyth-sdk-cw                    = { workspace = true }
 
-
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-cw-it                  = { workspace = true, features = ["multi-test"] }
-cw-multi-test          = { workspace = true }
+cw-it         = { workspace = true, features = ["multi-test"] }
+cw-multi-test = { workspace = true }

--- a/packages/types/Cargo.toml
+++ b/packages/types/Cargo.toml
@@ -23,5 +23,5 @@ cosmwasm-schema = { workspace = true }
 cosmwasm-std    = { workspace = true }
 mars-owner      = { workspace = true }
 mars-utils      = { workspace = true }
+strum           = { workspace = true, features = ["derive"] }
 thiserror       = { workspace = true }
-strum           = { workspace = true, features = ["derive"] }   


### PR DESCRIPTION
- remove unused dependencies and features
- format `Cargo.toml`s (align items and sort alphabetically)
- update all dependencies to latest (by running `cargo update`)
- disable doctest for all crates (we don't need it, so disabling speeds up CI by a little bit)