### PR TITLE
Validate if slippage not too high.

### DIFF
--- a/contracts/swapper/astroport/tests/test_swap.rs
+++ b/contracts/swapper/astroport/tests/test_swap.rs
@@ -54,9 +54,11 @@ const DEFAULT_LIQ: [u128; 2] = [10000000000000000u128, 10000000000000000u128];
 #[test_case(PoolType::Stable { amp: 10u64 }, "uatom", &DEFAULT_LIQ, &[6,6], Decimal::percent(5), true => panics ; "stable swap no route")]
 #[test_case(PoolType::Xyk {}, "uatom",  &DEFAULT_LIQ, &[10,6], Decimal::percent(1), false; "xyk 10:6 decimals, even pool")]
 #[test_case(PoolType::Xyk {}, "uatom",  &DEFAULT_LIQ, &[6,18], Decimal::percent(1), false; "xyk 6:18 decimals, even pool")]
-#[test_case(PoolType::Stable { amp: 10u64 }, "uatom", &[100000000000,10000000000000], &[6,8], Decimal::percent(50), false; "stable 6:8 decimals, even adjusted pool")]
-#[test_case(PoolType::Stable { amp: 10u64 }, "uatom", &[1000000000000,100000000000], &[7,6], Decimal::percent(50), false; "stable 8:6 decimals, even adjusted pool")]
+#[test_case(PoolType::Stable { amp: 10u64 }, "uatom", &[100000000000,10000000000000], &[6,8], Decimal::percent(10), false; "stable 6:8 decimals, even adjusted pool")]
+#[test_case(PoolType::Stable { amp: 10u64 }, "uatom", &[1000000000000,100000000000], &[7,6], Decimal::percent(10), false; "stable 8:6 decimals, even adjusted pool")]
 #[test_case(PoolType::Stable { amp: 10u64 }, "uatom", &[100000000000,100000000000000000000000], &[6,18], Decimal::percent(5), false; "stable 6:18 decimals, even adjusted pool")]
+#[test_case(PoolType::Xyk {}, "uatom", &DEFAULT_LIQ, &[6,6], Decimal::percent(11), false => panics ; "xyk max slippage exceeded")]
+#[test_case(PoolType::Stable { amp: 10u64 }, "uatom", &DEFAULT_LIQ, &[6,6], Decimal::percent(11), false => panics ; "stable max slippage exceeded")]
 fn swap(
     pool_type: PoolType,
     denom_out: &str,

--- a/contracts/swapper/base/src/contract.rs
+++ b/contracts/swapper/base/src/contract.rs
@@ -14,6 +14,9 @@ use mars_red_bank_types::swapper::{
 
 use crate::{ContractError, ContractResult, Route};
 
+// Max allowed slippage percentage for swap
+const MAX_SLIPPAGE_PERCENTAGE: u64 = 10;
+
 pub struct SwapBase<'a, Q, M, R>
 where
     Q: CustomQuery,
@@ -161,6 +164,14 @@ where
         denom_out: String,
         slippage: Decimal,
     ) -> ContractResult<Response<M>> {
+        let max_slippage = Decimal::percent(MAX_SLIPPAGE_PERCENTAGE);
+        if slippage > max_slippage {
+            return Err(ContractError::MaxSlippageExceeded {
+                max_slippage,
+                slippage,
+            });
+        }
+
         let swap_msg = self
             .routes
             .load(deps.storage, (coin_in.denom.clone(), denom_out.clone()))

--- a/contracts/swapper/base/src/error.rs
+++ b/contracts/swapper/base/src/error.rs
@@ -1,5 +1,5 @@
 use cosmwasm_std::{
-    CheckedFromRatioError, CheckedMultiplyFractionError, CheckedMultiplyRatioError,
+    CheckedFromRatioError, CheckedMultiplyFractionError, CheckedMultiplyRatioError, Decimal,
     DecimalRangeExceeded, OverflowError, StdError,
 };
 use mars_owner::OwnerError;
@@ -49,6 +49,12 @@ pub enum ContractError {
     NoRoute {
         from: String,
         to: String,
+    },
+
+    #[error("Max slippage of {max_slippage} exceeded. Slippage is {slippage}")]
+    MaxSlippageExceeded {
+        max_slippage: Decimal,
+        slippage: Decimal,
     },
 }
 


### PR DESCRIPTION
The slippage parameter is not explicitly sanity checked. The parameter could be set 100% in which case the user could receive no output coins as a result.

*Remediation*
The slippage parameter should be checked if it’s less than 1 and not exceed maximum amount e.g. max slippage 10%.