### PR TITLE
add max limit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2241,9 +2241,9 @@ checksum = "4d5d9eb14b174ee9aa2ef96dc2b94637a2d4b6e7cb873c7e171f0c20c6cf3eac"
 
 [[package]]
 name = "osmosis-std"
-version = "0.16.1"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fa46d2ad5ae738572887974e000934374ce3546b820505c0ee19ca708e49622"
+checksum = "75895e4db1a81ca29118e366365744f64314938327e4eedba8e6e462fb15e94f"
 dependencies = [
  "chrono",
  "cosmwasm-std",
@@ -2257,9 +2257,9 @@ dependencies = [
 
 [[package]]
 name = "osmosis-std-derive"
-version = "0.16.1"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11c2ba5535743617d6f44ae8d572d064fabab6d06ffcf403512f89c58954dbe9"
+checksum = "f47f0b2f22adb341bb59e5a3a1b464dde033181954bd055b9ae86d6511ba465b"
 dependencies = [
  "itertools",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ cw-storage-plus   = "1.1.0"
 cw-utils          = "1.0.1"
 mars-owner        = { version = "2.0.0", features = ["emergency-owner"] }
 neutron-sdk       = "0.6.1"
-osmosis-std       = "0.16.1"
+osmosis-std       = "0.16.2"
 prost             = { version = "0.11.9", default-features = false }
 pyth-sdk-cw       = "1.2.0"
 schemars          = "0.8.12"

--- a/contracts/oracle/osmosis/src/helpers.rs
+++ b/contracts/oracle/osmosis/src/helpers.rs
@@ -9,7 +9,7 @@ use crate::DowntimeDetector;
 /// 48 hours in seconds
 const TWO_DAYS_IN_SECONDS: u64 = 172800u64;
 
-/// Assert the Osmosis pool indicated by `pool_id` is of Balancer XYK or StableSwap and assets are OSMO and `denom`
+/// Assert the Osmosis pool indicated by `pool_id` is of Balancer XYK, StableSwap or ConcentratedLiquidity and assets are OSMO and `denom`
 pub fn assert_osmosis_pool_assets(
     pool: &Pool,
     denom: &str,
@@ -20,6 +20,7 @@ pub fn assert_osmosis_pool_assets(
             assert_osmosis_xyk_pool(balancer_pool)?;
         }
         Pool::StableSwap(_) => {}
+        Pool::ConcentratedLiquidity(_) => {}
     };
 
     assert_osmosis_pool_contains_two_assets(pool, denom, base_denom)?;
@@ -34,6 +35,11 @@ pub fn assert_osmosis_xyk_lp_pool(pool: &Pool) -> ContractResult<()> {
         Pool::StableSwap(stable_swap_pool) => {
             return Err(ContractError::InvalidPriceSource {
                 reason: format!("StableSwap pool not supported. Pool id {}", stable_swap_pool.id),
+            });
+        }
+        Pool::ConcentratedLiquidity(cl_pool) => {
+            return Err(ContractError::InvalidPriceSource {
+                reason: format!("ConcentratedLiquidity pool not supported. Pool id {}", cl_pool.id),
             });
         }
     };

--- a/contracts/oracle/osmosis/src/price_source.rs
+++ b/contracts/oracle/osmosis/src/price_source.rs
@@ -612,6 +612,14 @@ impl OsmosisPriceSourceChecked {
                     reason: format!("StableSwap pool not supported. Pool id {}", pool.id),
                 })
             }
+            Pool::ConcentratedLiquidity(pool) => {
+                return Err(ContractError::InvalidPrice {
+                    reason: format!(
+                        "ConcentratedLiquidity pool not supported. Pool id {}",
+                        pool.id
+                    ),
+                })
+            }
         };
 
         let coin0 = Pool::unwrap_coin(&pool.pool_assets[0].token)?;

--- a/contracts/oracle/osmosis/tests/tests/helpers/mod.rs
+++ b/contracts/oracle/osmosis/tests/tests/helpers/mod.rs
@@ -9,7 +9,7 @@ use cosmwasm_std::{
 };
 use mars_oracle_base::ContractError;
 use mars_oracle_osmosis::{contract::entry, msg::ExecuteMsg, OsmosisPriceSourceUnchecked};
-use mars_osmosis::{BalancerPool, StableSwapPool};
+use mars_osmosis::{BalancerPool, ConcentratedLiquidityPool, StableSwapPool};
 use mars_red_bank_types::oracle::msg::{InstantiateMsg, QueryMsg};
 use mars_testing::{mock_info, MarsMockQuerier};
 use osmosis_std::types::osmosis::{gamm::v1beta1::PoolAsset, poolmanager::v1beta1::PoolResponse};
@@ -90,6 +90,10 @@ pub fn setup_test_with_pools() -> OwnedDeps<MockStorage, MockApi, MarsMockQuerie
     let assets = vec![coin(42069, "uatom"), coin(69420, "uosmo")];
     deps.querier
         .set_query_pool_response(5555, prepare_query_stable_swap_pool_response(5555, &assets));
+
+    // Set ConcentratedLiquidity pool
+    deps.querier
+        .set_query_pool_response(6666, prepare_query_cl_pool_response(6666, "ujuno", "uosmo"));
 
     deps
 }
@@ -196,6 +200,29 @@ pub fn prepare_query_stable_swap_pool_response(pool_id: u64, assets: &[Coin]) ->
         pool_liquidity,
         scaling_factors: vec![100000u64, 113890u64],
         scaling_factor_controller: "osmo1k8c2m5cn322akk5wy8lpt87dd2f4yh9afcd7af".to_string(),
+    };
+    PoolResponse {
+        pool: Some(pool.to_any()),
+    }
+}
+
+pub fn prepare_query_cl_pool_response(pool_id: u64, token0: &str, token1: &str) -> PoolResponse {
+    let pool = ConcentratedLiquidityPool {
+        address: "osmo126pr9qp44aft4juw7x4ev4s2qdtnwe38jzwunec9pxt5cpzaaphqyagqpu".to_string(),
+        incentives_address: "osmo1h2mhtj3wmsdt3uacev9pgpg38hkcxhsmyyn9ums0ya6eddrsafjsxs9j03"
+            .to_string(),
+        spread_rewards_address: "osmo16j5sssw32xuk8a0kjj8n54g25ye6kr339nz5axf8lzyeajk0k22stsm36c"
+            .to_string(),
+        id: pool_id,
+        current_tick_liquidity: "3820025893854099618.699762490947860933".to_string(),
+        token0: token0.to_string(),
+        token1: token1.to_string(),
+        current_sqrt_price: "656651.537483144215151633465586753226461989".to_string(),
+        current_tick: 102311912,
+        tick_spacing: 100,
+        exponent_at_price_one: -6,
+        spread_factor: "0.002000000000000000".to_string(),
+        last_liquidity_update: None,
     };
     PoolResponse {
         pool: Some(pool.to_any()),

--- a/contracts/oracle/osmosis/tests/tests/test_set_price_source.rs
+++ b/contracts/oracle/osmosis/tests/tests/test_set_price_source.rs
@@ -991,11 +991,20 @@ fn setting_price_source_xyk_lp() {
     );
 
     // attempting to use StableSwap pool
-    let err = set_price_source_xyk_lp("atom_mars_lp", 5555).unwrap_err();
+    let err = set_price_source_xyk_lp("atom_uosmo_lp", 5555).unwrap_err();
     assert_eq!(
         err,
         ContractError::InvalidPriceSource {
             reason: "StableSwap pool not supported. Pool id 5555".to_string()
+        }
+    );
+
+    // attempting to use ConcentratedLiquid pool
+    let err = set_price_source_xyk_lp("ujuno_uosmo_lp", 6666).unwrap_err();
+    assert_eq!(
+        err,
+        ContractError::InvalidPriceSource {
+            reason: "ConcentratedLiquidity pool not supported. Pool id 6666".to_string()
         }
     );
 

--- a/contracts/params/src/query.rs
+++ b/contracts/params/src/query.rs
@@ -13,6 +13,7 @@ use crate::{
 };
 
 pub const DEFAULT_LIMIT: u32 = 10;
+pub const MAX_LIMIT: u32 = 30;
 
 pub fn query_all_asset_params(
     deps: Deps,
@@ -20,7 +21,7 @@ pub fn query_all_asset_params(
     limit: Option<u32>,
 ) -> StdResult<Vec<AssetParams>> {
     let start = start_after.as_ref().map(|denom| Bound::exclusive(denom.as_str()));
-    let limit = limit.unwrap_or(DEFAULT_LIMIT) as usize;
+    let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
     ASSET_PARAMS
         .range(deps.storage, start, None, Order::Ascending)
         .take(limit)
@@ -47,7 +48,7 @@ pub fn query_all_vault_configs(
         None => None,
     };
 
-    let limit = limit.unwrap_or(DEFAULT_LIMIT) as usize;
+    let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
 
     VAULT_CONFIGS
         .range(deps.storage, start, None, Order::Ascending)

--- a/packages/chains/osmosis/src/lib.rs
+++ b/packages/chains/osmosis/src/lib.rs
@@ -1,5 +1,8 @@
 pub mod helpers;
 
-pub use osmosis_std::types::osmosis::gamm::{
-    poolmodels::stableswap::v1beta1::Pool as StableSwapPool, v1beta1::Pool as BalancerPool,
+pub use osmosis_std::types::osmosis::{
+    concentratedliquidity::v1beta1::Pool as ConcentratedLiquidityPool,
+    gamm::{
+        poolmodels::stableswap::v1beta1::Pool as StableSwapPool, v1beta1::Pool as BalancerPool,
+    },
 };


### PR DESCRIPTION
In red-bank:contracts/params/src/query.rs:23 and line 50, the `query_all_asset_params` and `query_all_vault_configs` functions do not perform maximum validations for the caller-specified limit parameter. If the caller specified the limit parameter to a very large value, the query might fail due to an out-of-gas error.

We recommend performing maximum limit validations similar to red-bank:contracts/address-provider/src/contract.rs:153.