### PR TITLE
update-migration

### DIFF
--- a/contracts/incentives/src/contract.rs
+++ b/contracts/incentives/src/contract.rs
@@ -764,25 +764,21 @@ pub fn query_emissions(
 /// MIGRATION
 
 #[cfg_attr(not(feature = "library"), entry_point)]
-pub fn migrate(_deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
-    pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
-        Ok(Response::default())
-        let version = get_contract_version(deps.as_ref().storage)?;
+pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
+    let version = get_contract_version(deps.as_ref().storage)?;
 
-        if version.contract != CONTRACT_NAME {
-            return Err(ContractError::IncorrectContract {
-                expected: CONTRACT_NAME.to_string(),
-                found: version.contract,
-            });
-        }
-
-        set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
-
-        set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
-        Ok(Response::new()
-            .add_attribute("action", "migrate")
-            .add_attribute("contract", CONTRACT_NAME)
-            .add_attribute("old_version", version.version)
-            .add_attribute("new_version", CONTRACT_VERSION))
+    if version.contract != CONTRACT_NAME {
+        return Err(ContractError::IncorrectContract {
+            expected: CONTRACT_NAME.to_string(),
+            found: version.contract,
+        });
     }
+
+    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+
+    Ok(Response::new()
+        .add_attribute("action", "migrate")
+        .add_attribute("contract", CONTRACT_NAME)
+        .add_attribute("old_version", version.version)
+        .add_attribute("new_version", CONTRACT_VERSION))
 }

--- a/contracts/incentives/src/contract.rs
+++ b/contracts/incentives/src/contract.rs
@@ -4,7 +4,7 @@ use cosmwasm_std::{
     attr, to_binary, Addr, BankMsg, Binary, Coin, Coins, Decimal, Deps, DepsMut, Env, Event,
     MessageInfo, Order, Response, StdError, StdResult, Uint128,
 };
-use cw2::set_contract_version;
+use cw2::{get_contract_version, set_contract_version};
 use cw_storage_plus::Bound;
 use mars_owner::{OwnerInit::SetInitialOwner, OwnerUpdate};
 use mars_red_bank_types::{
@@ -765,5 +765,24 @@ pub fn query_emissions(
 
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn migrate(_deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
-    Ok(Response::default())
+    pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
+        Ok(Response::default())
+        let version = get_contract_version(deps.as_ref().storage)?;
+
+        if version.contract != CONTRACT_NAME {
+            return Err(ContractError::IncorrectContract {
+                expected: CONTRACT_NAME.to_string(),
+                found: version.contract,
+            });
+        }
+
+        set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+
+        set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+        Ok(Response::new()
+            .add_attribute("action", "migrate")
+            .add_attribute("contract", CONTRACT_NAME)
+            .add_attribute("old_version", version.version)
+            .add_attribute("new_version", CONTRACT_VERSION))
+    }
 }

--- a/contracts/incentives/src/error.rs
+++ b/contracts/incentives/src/error.rs
@@ -67,7 +67,6 @@ pub enum ContractError {
         denom: String,
     },
 
-
     #[error("Wrong contract for migration")]
     IncorrectContract {
         expected: String,

--- a/contracts/incentives/src/error.rs
+++ b/contracts/incentives/src/error.rs
@@ -66,6 +66,13 @@ pub enum ContractError {
     DuplicateDenom {
         denom: String,
     },
+
+
+    #[error("Wrong contract for migration")]
+    IncorrectContract {
+        expected: String,
+        found: String,
+    },
 }
 
 impl From<ContractError> for StdError {


### PR DESCRIPTION
The incentive contract inherits the version of the workspace in red-bank:Cargo.toml. During initialization, the version is indeed set correctly. However, during migration, the contract version is not updated in red-bank:contracts/incentives/src/contract.rs:767-769.
This could lead to confusion during future migrations as it will not be possible to be certain which version of the contract is deployed in production.