### PR TITLE
MP-3296 pagination

### DIFF
--- a/contracts/red-bank/src/contract.rs
+++ b/contracts/red-bank/src/contract.rs
@@ -187,6 +187,22 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> Result<Binary, ContractErro
                 limit,
             )?)
         }
+        QueryMsg::UserCollateralsV2 {
+            user,
+            account_id,
+            start_after,
+            limit,
+        } => {
+            let user_addr = deps.api.addr_validate(&user)?;
+            to_binary(&query::query_user_collaterals_v2(
+                deps,
+                &env.block,
+                user_addr,
+                account_id,
+                start_after,
+                limit,
+            )?)
+        }
         QueryMsg::UserPosition {
             user,
             account_id,

--- a/contracts/red-bank/src/query.rs
+++ b/contracts/red-bank/src/query.rs
@@ -223,14 +223,14 @@ pub fn query_user_collaterals_v2(
 
     let mut user_collaterals = user_collaterals_res?;
     let has_more = user_collaterals.len() > limit;
-    user_collaterals.pop(); // Remove the extra item used for checking if there are more items
-    let next_start_after = user_collaterals.last().map(|collateral| collateral.denom.clone());
+    if has_more {
+        user_collaterals.pop(); // Remove the extra item used for checking if there are more items
+    }
 
     Ok(PaginatedUserCollateralResponse {
         data: user_collaterals,
         metadata: Metadata {
             has_more,
-            next_start_after,
         },
     })
 }

--- a/contracts/red-bank/src/query.rs
+++ b/contracts/red-bank/src/query.rs
@@ -20,8 +20,8 @@ use crate::{
     state::{COLLATERALS, CONFIG, DEBTS, MARKETS, OWNER, UNCOLLATERALIZED_LOAN_LIMITS},
 };
 
-const DEFAULT_LIMIT: u32 = 5;
-const MAX_LIMIT: u32 = 10;
+const DEFAULT_LIMIT: u32 = 10;
+const MAX_LIMIT: u32 = 30;
 
 pub fn query_config(deps: Deps) -> StdResult<ConfigResponse> {
     let owner_state = OWNER.query(deps.storage)?;

--- a/packages/types/src/lib.rs
+++ b/packages/types/src/lib.rs
@@ -5,3 +5,17 @@ pub mod oracle;
 pub mod red_bank;
 pub mod rewards_collector;
 pub mod swapper;
+
+use cosmwasm_schema::cw_serde;
+
+#[cw_serde]
+pub struct PaginationResponse<T> {
+    pub data: Vec<T>,
+    pub metadata: Metadata,
+}
+
+#[cw_serde]
+pub struct Metadata {
+    pub has_more: bool,
+    pub next_start_after: Option<String>,
+}

--- a/packages/types/src/lib.rs
+++ b/packages/types/src/lib.rs
@@ -17,5 +17,4 @@ pub struct PaginationResponse<T> {
 #[cw_serde]
 pub struct Metadata {
     pub has_more: bool,
-    pub next_start_after: Option<String>,
 }

--- a/packages/types/src/red_bank/msg.rs
+++ b/packages/types/src/red_bank/msg.rs
@@ -195,6 +195,15 @@ pub enum QueryMsg {
         limit: Option<u32>,
     },
 
+    /// Get all collateral positions for a user
+    #[returns(Vec<crate::red_bank::PaginatedUserCollateralResponse>)]
+    UserCollateralsV2 {
+        user: String,
+        account_id: Option<String>,
+        start_after: Option<String>,
+        limit: Option<u32>,
+    },
+
     /// Get user position
     #[returns(crate::red_bank::UserPositionResponse)]
     UserPosition {

--- a/packages/types/src/red_bank/msg.rs
+++ b/packages/types/src/red_bank/msg.rs
@@ -196,7 +196,7 @@ pub enum QueryMsg {
     },
 
     /// Get all collateral positions for a user
-    #[returns(Vec<crate::red_bank::PaginatedUserCollateralResponse>)]
+    #[returns(crate::red_bank::PaginatedUserCollateralResponse)]
     UserCollateralsV2 {
         user: String,
         account_id: Option<String>,

--- a/packages/types/src/red_bank/types.rs
+++ b/packages/types/src/red_bank/types.rs
@@ -1,6 +1,8 @@
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{Decimal, Uint128};
 
+use crate::PaginationResponse;
+
 /// Global configuration
 #[cw_serde]
 pub struct Config<T> {
@@ -95,6 +97,8 @@ pub struct UserCollateralResponse {
     /// Wether the user is using asset as collateral or not
     pub enabled: bool,
 }
+
+pub type PaginatedUserCollateralResponse = PaginationResponse<UserCollateralResponse>;
 
 #[cw_serde]
 pub struct UserPositionResponse {

--- a/schemas/mars-red-bank/mars-red-bank.json
+++ b/schemas/mars-red-bank/mars-red-bank.json
@@ -823,6 +823,48 @@
         "additionalProperties": false
       },
       {
+        "description": "Get all collateral positions for a user",
+        "type": "object",
+        "required": [
+          "user_collaterals_v2"
+        ],
+        "properties": {
+          "user_collaterals_v2": {
+            "type": "object",
+            "required": [
+              "user"
+            ],
+            "properties": {
+              "account_id": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "limit": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint32",
+                "minimum": 0.0
+              },
+              "start_after": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "user": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      },
+      {
         "description": "Get user position",
         "type": "object",
         "required": [
@@ -1466,6 +1508,81 @@
         "$ref": "#/definitions/UserCollateralResponse"
       },
       "definitions": {
+        "Uint128": {
+          "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+          "type": "string"
+        },
+        "UserCollateralResponse": {
+          "type": "object",
+          "required": [
+            "amount",
+            "amount_scaled",
+            "denom",
+            "enabled"
+          ],
+          "properties": {
+            "amount": {
+              "description": "Underlying asset amount that is actually deposited at the current block",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Uint128"
+                }
+              ]
+            },
+            "amount_scaled": {
+              "description": "Scaled collateral amount stored in contract state",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Uint128"
+                }
+              ]
+            },
+            "denom": {
+              "description": "Asset denom",
+              "type": "string"
+            },
+            "enabled": {
+              "description": "Wether the user is using asset as collateral or not",
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false
+        }
+      }
+    },
+    "user_collaterals_v2": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "PaginationResponse_for_UserCollateralResponse",
+      "type": "object",
+      "required": [
+        "data",
+        "metadata"
+      ],
+      "properties": {
+        "data": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/UserCollateralResponse"
+          }
+        },
+        "metadata": {
+          "$ref": "#/definitions/Metadata"
+        }
+      },
+      "additionalProperties": false,
+      "definitions": {
+        "Metadata": {
+          "type": "object",
+          "required": [
+            "has_more"
+          ],
+          "properties": {
+            "has_more": {
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false
+        },
         "Uint128": {
           "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
           "type": "string"

--- a/scripts/types/generated/mars-red-bank/MarsRedBank.client.ts
+++ b/scripts/types/generated/mars-red-bank/MarsRedBank.client.ts
@@ -24,6 +24,8 @@ import {
   ArrayOfUncollateralizedLoanLimitResponse,
   UserCollateralResponse,
   ArrayOfUserCollateralResponse,
+  PaginationResponseForUserCollateralResponse,
+  Metadata,
   UserDebtResponse,
   ArrayOfUserDebtResponse,
   UserHealthStatus,
@@ -86,6 +88,17 @@ export interface MarsRedBankReadOnlyInterface {
     startAfter?: string
     user: string
   }) => Promise<ArrayOfUserCollateralResponse>
+  userCollateralsV2: ({
+    accountId,
+    limit,
+    startAfter,
+    user,
+  }: {
+    accountId?: string
+    limit?: number
+    startAfter?: string
+    user: string
+  }) => Promise<PaginationResponseForUserCollateralResponse>
   userPosition: ({
     accountId,
     user,
@@ -133,6 +146,7 @@ export class MarsRedBankQueryClient implements MarsRedBankReadOnlyInterface {
     this.userDebts = this.userDebts.bind(this)
     this.userCollateral = this.userCollateral.bind(this)
     this.userCollaterals = this.userCollaterals.bind(this)
+    this.userCollateralsV2 = this.userCollateralsV2.bind(this)
     this.userPosition = this.userPosition.bind(this)
     this.userPositionLiquidationPricing = this.userPositionLiquidationPricing.bind(this)
     this.scaledLiquidityAmount = this.scaledLiquidityAmount.bind(this)
@@ -259,6 +273,26 @@ export class MarsRedBankQueryClient implements MarsRedBankReadOnlyInterface {
   }): Promise<ArrayOfUserCollateralResponse> => {
     return this.client.queryContractSmart(this.contractAddress, {
       user_collaterals: {
+        account_id: accountId,
+        limit,
+        start_after: startAfter,
+        user,
+      },
+    })
+  }
+  userCollateralsV2 = async ({
+    accountId,
+    limit,
+    startAfter,
+    user,
+  }: {
+    accountId?: string
+    limit?: number
+    startAfter?: string
+    user: string
+  }): Promise<PaginationResponseForUserCollateralResponse> => {
+    return this.client.queryContractSmart(this.contractAddress, {
+      user_collaterals_v2: {
         account_id: accountId,
         limit,
         start_after: startAfter,

--- a/scripts/types/generated/mars-red-bank/MarsRedBank.react-query.ts
+++ b/scripts/types/generated/mars-red-bank/MarsRedBank.react-query.ts
@@ -25,6 +25,8 @@ import {
   ArrayOfUncollateralizedLoanLimitResponse,
   UserCollateralResponse,
   ArrayOfUserCollateralResponse,
+  PaginationResponseForUserCollateralResponse,
+  Metadata,
   UserDebtResponse,
   ArrayOfUserDebtResponse,
   UserHealthStatus,
@@ -78,6 +80,10 @@ export const marsRedBankQueryKeys = {
   userCollaterals: (contractAddress: string | undefined, args?: Record<string, unknown>) =>
     [
       { ...marsRedBankQueryKeys.address(contractAddress)[0], method: 'user_collaterals', args },
+    ] as const,
+  userCollateralsV2: (contractAddress: string | undefined, args?: Record<string, unknown>) =>
+    [
+      { ...marsRedBankQueryKeys.address(contractAddress)[0], method: 'user_collaterals_v2', args },
     ] as const,
   userPosition: (contractAddress: string | undefined, args?: Record<string, unknown>) =>
     [
@@ -273,6 +279,32 @@ export function useMarsRedBankUserPositionQuery<TData = UserPositionResponse>({
       client
         ? client.userPosition({
             accountId: args.accountId,
+            user: args.user,
+          })
+        : Promise.reject(new Error('Invalid client')),
+    { ...options, enabled: !!client && (options?.enabled != undefined ? options.enabled : true) },
+  )
+}
+export interface MarsRedBankUserCollateralsV2Query<TData>
+  extends MarsRedBankReactQuery<PaginationResponseForUserCollateralResponse, TData> {
+  args: {
+    accountId?: string
+    limit?: number
+    startAfter?: string
+    user: string
+  }
+}
+export function useMarsRedBankUserCollateralsV2Query<
+  TData = PaginationResponseForUserCollateralResponse,
+>({ client, args, options }: MarsRedBankUserCollateralsV2Query<TData>) {
+  return useQuery<PaginationResponseForUserCollateralResponse, Error, TData>(
+    marsRedBankQueryKeys.userCollateralsV2(client?.contractAddress, args),
+    () =>
+      client
+        ? client.userCollateralsV2({
+            accountId: args.accountId,
+            limit: args.limit,
+            startAfter: args.startAfter,
             user: args.user,
           })
         : Promise.reject(new Error('Invalid client')),

--- a/scripts/types/generated/mars-red-bank/MarsRedBank.types.ts
+++ b/scripts/types/generated/mars-red-bank/MarsRedBank.types.ts
@@ -163,6 +163,14 @@ export type QueryMsg =
       }
     }
   | {
+      user_collaterals_v2: {
+        account_id?: string | null
+        limit?: number | null
+        start_after?: string | null
+        user: string
+      }
+    }
+  | {
       user_position: {
         account_id?: string | null
         user: string
@@ -228,6 +236,13 @@ export interface UserCollateralResponse {
   enabled: boolean
 }
 export type ArrayOfUserCollateralResponse = UserCollateralResponse[]
+export interface PaginationResponseForUserCollateralResponse {
+  data: UserCollateralResponse[]
+  metadata: Metadata
+}
+export interface Metadata {
+  has_more: boolean
+}
 export interface UserDebtResponse {
   amount: Uint128
   amount_scaled: Uint128


### PR DESCRIPTION
Common way to do pagination in Cosmwasm is using `limit`, `start_after` and respond with vector of data. For example:
```
// settings for pagination
const MAX_LIMIT: u32 = 30;
const DEFAULT_LIMIT: u32 = 10;

pub fn query_list_members(
    deps: Deps,
    start_after: Option<String>,
    limit: Option<u32>,
) -> StdResult<MemberListResponse> {
    let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
    let addr = maybe_addr(deps.api, start_after)?;
    let start = addr.as_ref().map(Bound::exclusive);

    let members = MEMBERS
        .range(deps.storage, start, None, Order::Ascending)
        .take(limit)
        .map(|item| {
            item.map(|(addr, weight)| Member {
                addr: addr.into(),
                weight,
            })
        })
        .collect::<StdResult<_>>()?;

    Ok(MemberListResponse { members })
}
```

As an API user if I want to know if there is more data:
- check if responded number of elements is less than sent `limit` parameter. This is problematic because if I send `limit` > `MAX_LIMIT` I get less elements than requested - thinking that there is no more data.
- execute next query and see if there is more data. This is not efficient because I make extra query.
Moreover, it is easy to forget about pagination as we noticed during contract configuration / validation. You could query something and you basically use default pagination params and don't see the rest of elements.

*Solution*
Add metadata data
```
#[cw_serde]
pub struct PaginationResponse<T> {
    pub data: Vec<T>,
    pub metadata: Metadata,
}

#[cw_serde]
pub struct Metadata {
    pub has_more: bool,
    pub next_start_after: Option<String>,
}
```
This way we see in the response if there is more data. Easy to operate on without depending on default params.
