### PR TITLE
MP-3299, Oak no. 8, contract version update. MP-3310, Oak no. 19, provide whitelist count.

### DIFF
--- a/contracts/incentives/src/contract.rs
+++ b/contracts/incentives/src/contract.rs
@@ -620,6 +620,7 @@ pub fn query_config(deps: Deps) -> StdResult<ConfigResponse> {
         address_provider: config.address_provider,
         max_whitelisted_denoms: config.max_whitelisted_denoms,
         epoch_duration: EPOCH_DURATION.load(deps.storage)?,
+        whitelist_count: WHITELIST_COUNT.load(deps.storage)?,
     })
 }
 

--- a/contracts/incentives/src/contract.rs
+++ b/contracts/incentives/src/contract.rs
@@ -620,7 +620,7 @@ pub fn query_config(deps: Deps) -> StdResult<ConfigResponse> {
         address_provider: config.address_provider,
         max_whitelisted_denoms: config.max_whitelisted_denoms,
         epoch_duration: EPOCH_DURATION.load(deps.storage)?,
-        whitelist_count: WHITELIST_COUNT.load(deps.storage)?,
+        whitelist_count: WHITELIST_COUNT.may_load(deps.storage)?.unwrap_or_default(),
     })
 }
 

--- a/contracts/incentives/src/contract.rs
+++ b/contracts/incentives/src/contract.rs
@@ -4,7 +4,7 @@ use cosmwasm_std::{
     attr, to_binary, Addr, BankMsg, Binary, Coin, Coins, Decimal, Deps, DepsMut, Env, Event,
     MessageInfo, Order, Response, StdError, StdResult, Uint128,
 };
-use cw2::set_contract_version;
+use cw2::{get_contract_version, set_contract_version};
 use cw_storage_plus::Bound;
 use mars_owner::{OwnerInit::SetInitialOwner, OwnerUpdate};
 use mars_red_bank_types::{
@@ -764,6 +764,21 @@ pub fn query_emissions(
 /// MIGRATION
 
 #[cfg_attr(not(feature = "library"), entry_point)]
-pub fn migrate(_deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
-    Ok(Response::default())
+pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> Result<Response, ContractError> {
+    let version = get_contract_version(deps.as_ref().storage)?;
+
+    if version.contract != CONTRACT_NAME {
+        return Err(ContractError::IncorrectContract {
+            expected: CONTRACT_NAME.to_string(),
+            found: version.contract,
+        });
+    }
+
+    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+
+    Ok(Response::new()
+        .add_attribute("action", "migrate")
+        .add_attribute("contract", CONTRACT_NAME)
+        .add_attribute("old_version", version.version)
+        .add_attribute("new_version", CONTRACT_VERSION))
 }

--- a/contracts/incentives/src/error.rs
+++ b/contracts/incentives/src/error.rs
@@ -66,6 +66,12 @@ pub enum ContractError {
     DuplicateDenom {
         denom: String,
     },
+
+    #[error("Wrong contract for migration")]
+    IncorrectContract {
+        expected: String,
+        found: String,
+    },
 }
 
 impl From<ContractError> for StdError {

--- a/contracts/incentives/tests/tests/test_admin.rs
+++ b/contracts/incentives/tests/tests/test_admin.rs
@@ -32,6 +32,9 @@ fn proper_initialization() {
     assert_eq!(config.owner, Some("owner".to_string()));
     assert_eq!(config.proposed_new_owner, None);
     assert_eq!(config.address_provider, "address_provider".to_string());
+    assert_eq!(config.epoch_duration, 604800);
+    assert_eq!(config.max_whitelisted_denoms, 10);
+    assert_eq!(config.whitelist_count, 0);
 }
 
 #[test]
@@ -87,5 +90,7 @@ fn update_config() {
     assert_eq!(new_config.owner, Some("owner".to_string()));
     assert_eq!(new_config.proposed_new_owner, None);
     assert_eq!(new_config.address_provider, Addr::unchecked("new_addr_provider"));
+    assert_eq!(new_config.epoch_duration, 604800);
+    assert_eq!(new_config.whitelist_count, 0);
     assert_eq!(new_config.max_whitelisted_denoms, 20);
 }

--- a/contracts/incentives/tests/tests/test_whitelist.rs
+++ b/contracts/incentives/tests/tests/test_whitelist.rs
@@ -10,7 +10,7 @@ use mars_incentives::{
 };
 use mars_owner::OwnerError::NotOwner;
 use mars_red_bank_types::{
-    incentives::{ExecuteMsg, QueryMsg, WhitelistEntry},
+    incentives::{ConfigResponse, ExecuteMsg, QueryMsg, WhitelistEntry},
     red_bank::{Market, UserCollateralResponse},
 };
 use mars_testing::MockEnvParams;
@@ -356,8 +356,8 @@ fn cannot_whitelist_more_than_max_limit() {
     execute(deps.as_mut(), mock_env(), mock_info(owner, &[]), add_whitelist_msg).unwrap();
 
     // Check whitelist count. Should still be 10.
-    let whitelist_count = WHITELIST_COUNT.load(&deps.storage).unwrap();
-    assert_eq!(whitelist_count, 10);
+    let config: ConfigResponse = th_query(deps.as_ref(), QueryMsg::Config {});
+    assert_eq!(config.max_whitelisted_denoms, 10);
 }
 
 #[test]

--- a/packages/types/src/incentives.rs
+++ b/packages/types/src/incentives.rs
@@ -303,4 +303,6 @@ pub struct ConfigResponse {
     pub max_whitelisted_denoms: u8,
     /// The epoch duration in seconds
     pub epoch_duration: u64,
+    /// The count of the number of whitelisted incentive denoms
+    pub whitelist_count: u8,
 }

--- a/schemas/mars-incentives/mars-incentives.json
+++ b/schemas/mars-incentives/mars-incentives.json
@@ -688,7 +688,8 @@
       "required": [
         "address_provider",
         "epoch_duration",
-        "max_whitelisted_denoms"
+        "max_whitelisted_denoms",
+        "whitelist_count"
       ],
       "properties": {
         "address_provider": {
@@ -724,6 +725,12 @@
             "string",
             "null"
           ]
+        },
+        "whitelist_count": {
+          "description": "The count of the number of whitelisted incentive denoms",
+          "type": "integer",
+          "format": "uint8",
+          "minimum": 0.0
         }
       },
       "additionalProperties": false,

--- a/scripts/types/generated/mars-incentives/MarsIncentives.types.ts
+++ b/scripts/types/generated/mars-incentives/MarsIncentives.types.ts
@@ -134,6 +134,7 @@ export interface ConfigResponse {
   max_whitelisted_denoms: number
   owner?: string | null
   proposed_new_owner?: string | null
+  whitelist_count: number
 }
 export type ArrayOfEmissionResponse = EmissionResponse[]
 export interface EmissionResponse {


### PR DESCRIPTION
The incentive contract inherits the version of the workspace in red-bank:Cargo.toml. During initialization, the version is indeed set correctly. However, during migration, the contract version is not updated in red-bank:contracts/incentives/src/contract.rs:767-769.
This could lead to confusion during future migrations as it will not be possible to be certain which version of the contract is deployed in production.