### PR TITLE
MP-3311. Oak no. 20.

### DIFF
--- a/contracts/params/src/query.rs
+++ b/contracts/params/src/query.rs
@@ -13,6 +13,7 @@ use crate::{
 };
 
 pub const DEFAULT_LIMIT: u32 = 10;
+pub const MAX_LIMIT: u32 = 30;
 
 pub fn query_all_asset_params(
     deps: Deps,
@@ -20,7 +21,7 @@ pub fn query_all_asset_params(
     limit: Option<u32>,
 ) -> StdResult<Vec<AssetParams>> {
     let start = start_after.as_ref().map(|denom| Bound::exclusive(denom.as_str()));
-    let limit = limit.unwrap_or(DEFAULT_LIMIT) as usize;
+    let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
     ASSET_PARAMS
         .range(deps.storage, start, None, Order::Ascending)
         .take(limit)
@@ -47,7 +48,7 @@ pub fn query_all_vault_configs(
         None => None,
     };
 
-    let limit = limit.unwrap_or(DEFAULT_LIMIT) as usize;
+    let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
 
     VAULT_CONFIGS
         .range(deps.storage, start, None, Order::Ascending)


### PR DESCRIPTION


In red-bank:contracts/params/src/query.rs:23 and line 50, the query_all_asset_params and query_all_vault_configs functions do not perform maximum validations for the caller-specified limit parameter. If the caller specified the limit parameter to a very large value, the query might fail due to an out-of-gas error.

We recommend performing maximum limit validations similar to red-bank:contracts/address-provider/src/contract.rs:153.
