### PR TITLE
Revert deposit on behalf of

### DIFF
--- a/contracts/red-bank/src/contract.rs
+++ b/contracts/red-bank/src/contract.rs
@@ -50,9 +50,18 @@ pub fn execute(
         }
         ExecuteMsg::Deposit {
             account_id,
+            on_behalf_of,
         } => {
             let sent_coin = cw_utils::one_coin(&info)?;
-            deposit::deposit(deps, env, info, sent_coin.denom, sent_coin.amount, account_id)
+            deposit::deposit(
+                deps,
+                env,
+                info,
+                on_behalf_of,
+                sent_coin.denom,
+                sent_coin.amount,
+                account_id,
+            )
         }
         ExecuteMsg::Withdraw {
             denom,

--- a/contracts/red-bank/tests/tests/test_deposit.rs
+++ b/contracts/red-bank/tests/tests/test_deposit.rs
@@ -590,10 +590,11 @@ fn depositing_on_behalf_of_cannot_enable_collateral() {
 }
 
 #[test]
-fn depositing_by_credit_manager_on_behalf_of() {
+fn depositing_on_behalf_of_credit_manager() {
     let TestSuite {
         mut deps,
         denom,
+        depositor_addr,
         ..
     } = setup_test();
 
@@ -616,10 +617,10 @@ fn depositing_by_credit_manager_on_behalf_of() {
     let err = execute(
         deps.as_mut(),
         mock_env(),
-        mock_info("credit_manager", &coins(123, denom)),
+        mock_info(depositor_addr.as_str(), &coins(123, denom)),
         ExecuteMsg::Deposit {
             account_id: None,
-            on_behalf_of: Some("some_user".to_string()),
+            on_behalf_of: Some("credit_manager".to_string()),
         },
     )
     .unwrap_err();

--- a/contracts/red-bank/tests/tests/test_liquidate.rs
+++ b/contracts/red-bank/tests/tests/test_liquidate.rs
@@ -746,6 +746,7 @@ fn response_verification() {
         mock_info(provider.as_str(), &[coin(1000000, "uusdc")]),
         ExecuteMsg::Deposit {
             account_id: None,
+            on_behalf_of: None,
         },
     )
     .unwrap();
@@ -755,6 +756,7 @@ fn response_verification() {
         mock_info(provider.as_str(), &[coin(1000000, "untrn")]),
         ExecuteMsg::Deposit {
             account_id: None,
+            on_behalf_of: None,
         },
     )
     .unwrap();
@@ -766,6 +768,7 @@ fn response_verification() {
         mock_info(liquidatee.as_str(), &[coin(10000, "uosmo")]),
         ExecuteMsg::Deposit {
             account_id: None,
+            on_behalf_of: None,
         },
     )
     .unwrap();
@@ -775,6 +778,7 @@ fn response_verification() {
         mock_info(liquidatee.as_str(), &[coin(900, "uatom")]),
         ExecuteMsg::Deposit {
             account_id: None,
+            on_behalf_of: None,
         },
     )
     .unwrap();

--- a/integration-tests/tests/test_oracles.rs
+++ b/integration-tests/tests/test_oracles.rs
@@ -953,6 +953,7 @@ fn redbank_should_fail_if_no_price() {
         &red_bank_addr,
         &Deposit {
             account_id: None,
+            on_behalf_of: None,
         },
         &[coin(1_000_000, "uatom")],
         depositor,
@@ -1015,6 +1016,7 @@ fn redbank_quering_oracle_successfully() {
         &red_bank_addr,
         &Deposit {
             account_id: None,
+            on_behalf_of: None,
         },
         &[coin(1_000_000, "uatom")],
         depositor,

--- a/packages/testing/src/integration/mock_env.rs
+++ b/packages/testing/src/integration/mock_env.rs
@@ -355,6 +355,7 @@ impl RedBank {
             self.contract_addr.clone(),
             &red_bank::ExecuteMsg::Deposit {
                 account_id,
+                on_behalf_of: None,
             },
             &[coin],
         )

--- a/packages/types/src/red_bank/msg.rs
+++ b/packages/types/src/red_bank/msg.rs
@@ -56,6 +56,9 @@ pub enum ExecuteMsg {
     Deposit {
         /// Credit account id (Rover)
         account_id: Option<String>,
+
+        /// Address that will receive the coins
+        on_behalf_of: Option<String>,
     },
 
     /// Withdraw native coins

--- a/schemas/mars-red-bank/mars-red-bank.json
+++ b/schemas/mars-red-bank/mars-red-bank.json
@@ -196,6 +196,13 @@
                   "string",
                   "null"
                 ]
+              },
+              "on_behalf_of": {
+                "description": "Address that will receive the coins",
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             },
             "additionalProperties": false

--- a/scripts/deploy/base/deployer.ts
+++ b/scripts/deploy/base/deployer.ts
@@ -130,7 +130,6 @@ export class Deployer {
       owner: this.deployerAddress,
       config: {
         address_provider: this.storage.addresses['address-provider']!,
-        close_factor: '0.5',
       },
     }
     await this.instantiate('red-bank', this.storage.codeIds['red-bank']!, msg)

--- a/scripts/deploy/base/deployer.ts
+++ b/scripts/deploy/base/deployer.ts
@@ -130,6 +130,7 @@ export class Deployer {
       owner: this.deployerAddress,
       config: {
         address_provider: this.storage.addresses['address-provider']!,
+        close_factor: '0.5',
       },
     }
     await this.instantiate('red-bank', this.storage.codeIds['red-bank']!, msg)

--- a/scripts/types/generated/mars-red-bank/MarsRedBank.client.ts
+++ b/scripts/types/generated/mars-red-bank/MarsRedBank.client.ts
@@ -445,8 +445,10 @@ export interface MarsRedBankInterface extends MarsRedBankReadOnlyInterface {
   deposit: (
     {
       accountId,
+      onBehalfOf,
     }: {
       accountId?: string
+      onBehalfOf?: string
     },
     fee?: number | StdFee | 'auto',
     memo?: string,
@@ -668,8 +670,10 @@ export class MarsRedBankClient extends MarsRedBankQueryClient implements MarsRed
   deposit = async (
     {
       accountId,
+      onBehalfOf,
     }: {
       accountId?: string
+      onBehalfOf?: string
     },
     fee: number | StdFee | 'auto' = 'auto',
     memo?: string,
@@ -681,6 +685,7 @@ export class MarsRedBankClient extends MarsRedBankQueryClient implements MarsRed
       {
         deposit: {
           account_id: accountId,
+          on_behalf_of: onBehalfOf,
         },
       },
       fee,

--- a/scripts/types/generated/mars-red-bank/MarsRedBank.react-query.ts
+++ b/scripts/types/generated/mars-red-bank/MarsRedBank.react-query.ts
@@ -636,6 +636,7 @@ export interface MarsRedBankDepositMutation {
   client: MarsRedBankClient
   msg: {
     accountId?: string
+    onBehalfOf?: string
   }
   args?: {
     fee?: number | StdFee | 'auto'

--- a/scripts/types/generated/mars-red-bank/MarsRedBank.types.ts
+++ b/scripts/types/generated/mars-red-bank/MarsRedBank.types.ts
@@ -43,6 +43,7 @@ export type ExecuteMsg =
   | {
       deposit: {
         account_id?: string | null
+        on_behalf_of?: string | null
       }
     }
   | {


### PR DESCRIPTION
Calc finance uses deposit `on_behalf_of`.

- First commit reverts https://github.com/mars-protocol/red-bank/pull/230 (excluding `yarn` changes). Issue https://delphilabs.atlassian.net/browse/MP-2840
- Second one blocks credit manager contract from using `on_behalf_of`.