### PR TITLE
MP-3345. MP-3348. Don't allow red-bank users to create alternative account ids.

### DIFF
--- a/contracts/red-bank/src/deposit.rs
+++ b/contracts/red-bank/src/deposit.rs
@@ -39,6 +39,13 @@ pub fn deposit(
     let params_addr = &addresses[&MarsAddressType::Params];
     let credit_manager_addr = &addresses[&MarsAddressType::CreditManager];
 
+    // Don't allow red-bank users to create alternative account ids.
+    // Only allow credit-manager contract to create them.
+    // Even if account_id contains empty string we won't allow it.
+    if account_id.is_some() && info.sender != credit_manager_addr {
+        return Err(ContractError::Mars(MarsError::Unauthorized {}));
+    }
+
     let user_addr: Addr;
     let user = match on_behalf_of.as_ref() {
         // A malicious user can permanently disable the lend action in credit-manager contract by performing the following steps:

--- a/contracts/red-bank/tests/tests/test_credit_accounts.rs
+++ b/contracts/red-bank/tests/tests/test_credit_accounts.rs
@@ -17,7 +17,7 @@ fn deposit_and_withdraw_for_credit_account_works() {
 
     let funded_amt = 1_000_000_000_000u128;
     let provider = Addr::unchecked("provider"); // provides collateral to be borrowed by others
-    let credit_manager = Addr::unchecked("credit_manager");
+    let credit_manager = mock_env.credit_manager.clone();
     let account_id = "111".to_string();
 
     // setup red-bank


### PR DESCRIPTION
Fixes to @thec00n findings:

- no. 1 (red-bank users with alternative account ids might not be able to withdraw their funds). 
Do not allow red-bank users to create alternative account ids only allow the credit manager to create them by only allowing the credit manager contract to interact with the deposit and withdraw endpoint.

- no. 4 (account_id is not validated in red-bank)
red-bank should not allow users to create account-ids directly and any action should use the default account “”. Only the credit manager should be allowed to create custom account ids because validation is performed for all actions.