### PR TITLE
MP-3350. Use slippage

### DIFF
--- a/contracts/rewards-collector/osmosis/tests/tests/test_withdraw.rs
+++ b/contracts/rewards-collector/osmosis/tests/tests/test_withdraw.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{coin, testing::mock_env, to_binary, CosmosMsg, SubMsg, Uint128, WasmMsg};
+use cosmwasm_std::{testing::mock_env, to_binary, CosmosMsg, Decimal, SubMsg, Uint128, WasmMsg};
 use mars_red_bank_types::rewards_collector::{
     credit_manager::{self, Action, ActionAmount, ActionCoin},
     ExecuteMsg,
@@ -55,14 +55,17 @@ fn withdrawing_from_cm_if_action_not_allowed() {
         ExecuteMsg::WithdrawFromCreditManager {
             account_id: "random_id".to_string(),
             actions: vec![
-                Action::Withdraw(coin(100u128, "uatom")),
+                Action::Withdraw(ActionCoin {
+                    denom: "uatom".to_string(),
+                    amount: ActionAmount::Exact(Uint128::new(100)),
+                }),
                 Action::Unknown {},
                 Action::WithdrawLiquidity {
                     lp_token: ActionCoin {
                         denom: "gamm/pool/1".to_string(),
                         amount: ActionAmount::AccountBalance,
                     },
-                    minimum_receive: vec![],
+                    slippage: Decimal::percent(5),
                 },
             ],
         },
@@ -77,16 +80,25 @@ fn withdrawing_from_cm_successfully() {
 
     let account_id = "random_id".to_string();
     let actions = vec![
-        Action::Withdraw(coin(100u128, "uusdc")),
+        Action::Withdraw(ActionCoin {
+            denom: "uusdc".to_string(),
+            amount: ActionAmount::Exact(Uint128::new(100)),
+        }),
         Action::WithdrawLiquidity {
             lp_token: ActionCoin {
                 denom: "gamm/pool/1".to_string(),
                 amount: ActionAmount::AccountBalance,
             },
-            minimum_receive: vec![],
+            slippage: Decimal::percent(5),
         },
-        Action::Withdraw(coin(120u128, "uatom")),
-        Action::Withdraw(coin(140u128, "uosmo")),
+        Action::Withdraw(ActionCoin {
+            denom: "uatom".to_string(),
+            amount: ActionAmount::Exact(Uint128::new(120)),
+        }),
+        Action::Withdraw(ActionCoin {
+            denom: "uosmo".to_string(),
+            amount: ActionAmount::Exact(Uint128::new(140)),
+        }),
     ];
 
     // anyone can execute a withdrawal

--- a/packages/types/src/rewards_collector.rs
+++ b/packages/types/src/rewards_collector.rs
@@ -203,7 +203,7 @@ pub enum QueryMsg {
 // TODO: rover is private repo for now so can't use it as a dependency. Use rover types once repo is public.
 pub mod credit_manager {
     use cosmwasm_schema::cw_serde;
-    use cosmwasm_std::{Coin, Uint128};
+    use cosmwasm_std::{Decimal, Uint128};
 
     #[cw_serde]
     pub enum ExecuteMsg {
@@ -215,10 +215,10 @@ pub mod credit_manager {
 
     #[cw_serde]
     pub enum Action {
-        Withdraw(Coin),
+        Withdraw(ActionCoin),
         WithdrawLiquidity {
             lp_token: ActionCoin,
-            minimum_receive: Vec<Coin>,
+            slippage: Decimal, // value validated in credit-manager
         },
         Unknown {}, // Used to simulate allowance only for: Withdraw and WithdrawLiquidity
     }

--- a/schemas/mars-rewards-collector-base/mars-rewards-collector-base.json
+++ b/schemas/mars-rewards-collector-base/mars-rewards-collector-base.json
@@ -338,7 +338,7 @@
             ],
             "properties": {
               "withdraw": {
-                "$ref": "#/definitions/Coin"
+                "$ref": "#/definitions/ActionCoin"
               }
             },
             "additionalProperties": false
@@ -353,17 +353,14 @@
                 "type": "object",
                 "required": [
                   "lp_token",
-                  "minimum_receive"
+                  "slippage"
                 ],
                 "properties": {
                   "lp_token": {
                     "$ref": "#/definitions/ActionCoin"
                   },
-                  "minimum_receive": {
-                    "type": "array",
-                    "items": {
-                      "$ref": "#/definitions/Coin"
-                    }
+                  "slippage": {
+                    "$ref": "#/definitions/Decimal"
                   }
                 },
                 "additionalProperties": false

--- a/scripts/types/generated/mars-rewards-collector-base/MarsRewardsCollectorBase.types.ts
+++ b/scripts/types/generated/mars-rewards-collector-base/MarsRewardsCollectorBase.types.ts
@@ -85,12 +85,12 @@ export type OwnerUpdate =
   | 'clear_emergency_owner'
 export type Action =
   | {
-      withdraw: Coin
+      withdraw: ActionCoin
     }
   | {
       withdraw_liquidity: {
         lp_token: ActionCoin
-        minimum_receive: Coin[]
+        slippage: Decimal
       }
     }
   | {


### PR DESCRIPTION
It uses latest API from this PR https://github.com/mars-protocol/rover/pull/197

It fix problem rised by @thec00n (slippage is now validated in credit-manager):
```
Users can trigger reward withdrawal by calling Withdraw or WithdrawLiquidity from credit manager. A malicious user can send the WithdrawLiquidity and set the minimum_receive assets to zero. 
```